### PR TITLE
Adds workflows for CI testing

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,0 +1,25 @@
+# Workflow file for slow tests & on multiple python versions
+name: Integration tests
+on:
+  pull_request_review:
+    types: [approved]
+  workflow_dispatch:  # <-- can be triggered manually!
+
+jobs:
+  integration-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13]
+        python-version: [3.10, 3.11, 3.12]
+    steps:
+      - name: Set up Python version ${{ matrix.version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.version }}
+      - name: Install package and requirements
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install .
+      - name: Run pytest
+        run: pytest -s tests/ --cov=rascal2 --cov-report=term

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,36 @@
+# Workflow file for fast unit tests which run on all commits
+name: Unit tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1
+      - uses: chartboost/ruff-action@v1
+        with:
+          args: 'format --check'
+          
+  unit-tests:
+    name: Unit tests
+    needs: ruff  # avoid wasting CI time if static analysis failed
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13]
+    
+    steps:
+      - uses: actions/checkout@v4      
+      - name: Set up Conda environment from environment.yaml
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          environment-file: environment.yaml
+          auto-activate-base: false
+      - name: Install RasCAL2
+        run: pip install .
+      - name: Run pytest
+        run: pytest -s tests/ -m "not slow" --cov=rascal2 --cov-report=term

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers = 
+    slow: marks slow tests which only run on review


### PR DESCRIPTION
Fixes #10 by adding infrastructure for CI testing. 

I've added the functionality for a pytest `mark` to indicate tests that are slow (which we want to run on review rather than for every commit). A test can be flagged as slow with the decorator `@pytest.mark.slow`, and an entire test file can be marked as slow by setting the global variable `pytestmark = 'slow'`

The unit tests are run in a miniconda env set up to use our `environment.yaml`, and the slow integration tests are run on bare metal over all Python versions that Python actively supports (3.10, 3.11, 3.12). 