### PR TITLE
Standardises method names and adds linting for todos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,3 +50,5 @@ Style guidelines
 ----------------
 * Docstrings should be written in the numpydoc format.
 * `ruff format` must be used to format code.
+* Method names should be written in snake case (like_this). If you are overriding a PyQt6 method,
+  add it to `extend-ignore-names` in the section `[tool.ruff.lint.pep8-naming]` in the pyproject.toml.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,5 @@ fixture-parentheses = false
 mark-parentheses = false
 
 [tool.ruff.lint.pep8-naming]
+# if overriding a PyQt method, please add it here!
 extend-ignore-names = ["allKeys"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,12 @@ Repository = "https://github.com/RascalSoftware/RasCAL-2"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "UP", "B", "SIM", "I"]
-ignore = ["SIM108"]
+select = ["E", "F", "UP", "B", "SIM", "I", "N", "TD003"]
+ignore = ["SIM108", "N817"]
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
+
+[tool.ruff.lint.pep8-naming]
+extend-ignore-names = ["allKeys"]

--- a/rascal2/config.py
+++ b/rascal2/config.py
@@ -76,6 +76,7 @@ def setup_logging(log_path: str | PathLike, level: int = logging.INFO) -> loggin
     logger.setLevel(level)
 
     # TODO add console print handler when console is added
+    # https://github.com/RascalSoftware/RasCAL-2/issues/5
     log_filehandler = logging.FileHandler(path)
     logger.addHandler(log_filehandler)
 

--- a/rascal2/dialogs/project_dialog.py
+++ b/rascal2/dialogs/project_dialog.py
@@ -172,7 +172,7 @@ class ProjectDialog(QtWidgets.QDialog):
         self.verify_name()
         self.verify_folder()
         if self.project_name_error.isHidden() and self.project_folder_error.isHidden():
-            self.parent().presenter.createProject(self.project_name.text(), self.project_folder.text())
+            self.parent().presenter.create_project(self.project_name.text(), self.project_folder.text())
             if not self.parent().toolbar.isEnabled():
                 self.parent().toolbar.setEnabled(True)
             self.accept()

--- a/rascal2/main.py
+++ b/rascal2/main.py
@@ -17,6 +17,7 @@ def ui_execute():
     """
     handle_scaling()
     # TODO: Setup stylesheets
+    # https://github.com/RascalSoftware/RasCAL-2/issues/17
     app = QtWidgets.QApplication(sys.argv[:1])
     app.setWindowIcon(QtGui.QIcon(path_for("logo.png")))
 
@@ -27,7 +28,7 @@ def ui_execute():
 
 def main():
     multiprocessing.freeze_support()
-    # TODO: Initialise Logging
+
     exit_code = ui_execute()
     sys.exit(exit_code)
 

--- a/rascal2/ui/model.py
+++ b/rascal2/ui/model.py
@@ -14,7 +14,7 @@ class MainWindowModel(QtCore.QObject):
 
         self.save_path = ""
 
-    def createProject(self, name: str, save_path: str):
+    def create_project(self, name: str, save_path: str):
         """Creates a new RAT project and controls object.
 
         Parameters

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -26,8 +26,8 @@ class MainWindowPresenter:
             The save path of the project.
         """
 
-        self.model.createProject(name, save_path)
         self.view.setWindowTitle(self.title + " - " + name)
+        self.model.create_project(name, save_path)
         # TODO if the view's central widget is the startup one then setup MDI else reset the widgets.
         # https://github.com/RascalSoftware/RasCAL-2/issues/15
         self.view.init_settings_and_log(save_path)

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -15,7 +15,7 @@ class MainWindowPresenter:
         self.model = MainWindowModel()
         self.title = self.view.windowTitle()
 
-    def createProject(self, name: str, save_path: str):
+    def create_project(self, name: str, save_path: str):
         """Creates a new RAT project and controls object then initialise UI.
 
         Parameters
@@ -29,5 +29,6 @@ class MainWindowPresenter:
         self.model.createProject(name, save_path)
         self.view.setWindowTitle(self.title + " - " + name)
         # TODO if the view's central widget is the startup one then setup MDI else reset the widgets.
+        # https://github.com/RascalSoftware/RasCAL-2/issues/15
         self.view.init_settings_and_log(save_path)
-        self.view.setupMDI()
+        self.view.setup_mdi()

--- a/rascal2/ui/view.py
+++ b/rascal2/ui/view.py
@@ -50,7 +50,7 @@ class MainWindowView(QtWidgets.QMainWindow):
 
         self.setCentralWidget(self.startup_dlg)
 
-    def showProjectDialog(self):
+    def show_project_dialog(self):
         """Shows the project dialog to create a new project"""
         if self.startup_dlg.isVisible():
             self.startup_dlg.hide()
@@ -67,7 +67,7 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.new_project_action = QtGui.QAction("&New", self)
         self.new_project_action.setStatusTip("Create a new project")
         self.new_project_action.setIcon(QtGui.QIcon(path_for("new-project.png")))
-        self.new_project_action.triggered.connect(self.showProjectDialog)
+        self.new_project_action.triggered.connect(self.show_project_dialog)
         self.new_project_action.setShortcut(QtGui.QKeySequence.StandardKey.New)
 
         self.open_project_action = QtGui.QAction("&Open", self)
@@ -97,7 +97,7 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.open_help_action = QtGui.QAction("&Help", self)
         self.open_help_action.setStatusTip("Open Documentation")
         self.open_help_action.setIcon(QtGui.QIcon(path_for("help.png")))
-        self.open_help_action.triggered.connect(self.openDocs)
+        self.open_help_action.triggered.connect(self.open_docs)
 
         self.exit_action = QtGui.QAction("E&xit", self)
         self.exit_action.setStatusTip(f"Quit {MAIN_WINDOW_TITLE}")
@@ -132,7 +132,7 @@ class MainWindowView(QtWidgets.QMainWindow):
         help_menu = main_menu.addMenu("&Help")
         help_menu.addAction(self.open_help_action)
 
-    def openDocs(self):
+    def open_docs(self):
         """Opens the documentation"""
         url = QtCore.QUrl("https://rascalsoftware.github.io/RAT-Docs/dev/index.html")
         QtGui.QDesktopServices.openUrl(url)

--- a/rascal2/ui/view.py
+++ b/rascal2/ui/view.py
@@ -29,6 +29,10 @@ class MainWindowView(QtWidgets.QMainWindow):
 
         self.mdi = QtWidgets.QMdiArea()
         # TODO replace the widgets below
+        # plotting: NO ISSUE YET
+        # https://github.com/RascalSoftware/RasCAL-2/issues/5
+        # https://github.com/RascalSoftware/RasCAL-2/issues/7
+        # project: NO ISSUE YET
         self.plotting_widget = QtWidgets.QWidget()
         self.terminal_widget = QtWidgets.QWidget()
         self.controls_widget = QtWidgets.QWidget()
@@ -57,7 +61,7 @@ class MainWindowView(QtWidgets.QMainWindow):
         ):
             self.startup_dlg.show()
 
-    def createActions(self):
+    def create_actions(self):
         """Creates the menu and toolbar actions"""
 
         self.new_project_action = QtGui.QAction("&New", self)
@@ -106,7 +110,7 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.tile_windows_action.setIcon(QtGui.QIcon(path_for("tile.png")))
         self.tile_windows_action.triggered.connect(self.mdi.tileSubWindows)
 
-    def createMenus(self):
+    def create_menus(self):
         """Creates the main menu and sub menus"""
         main_menu = self.menuBar()
         main_menu.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.PreventContextMenu)
@@ -133,7 +137,7 @@ class MainWindowView(QtWidgets.QMainWindow):
         url = QtCore.QUrl("https://rascalsoftware.github.io/RAT-Docs/dev/index.html")
         QtGui.QDesktopServices.openUrl(url)
 
-    def createToolBar(self):
+    def create_toolbar(self):
         """Creates the toolbar"""
         self.toolbar = self.addToolBar("ToolBar")
         self.toolbar.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.PreventContextMenu)
@@ -148,12 +152,12 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.toolbar.addAction(self.export_plots_action)
         self.toolbar.addAction(self.open_help_action)
 
-    def createStatusBar(self):
+    def create_status_bar(self):
         """Creates the status bar"""
         sb = QtWidgets.QStatusBar()
         self.setStatusBar(sb)
 
-    def setupMDI(self):
+    def setup_mdi(self):
         """Creates the multi-document interface"""
         widgets = {
             "Plots": self.plotting_widget,
@@ -169,6 +173,7 @@ class MainWindowView(QtWidgets.QMainWindow):
             )
             window.setWindowTitle(title)
         # TODO implement user save for layouts, this should default to use saved layout and fallback to tile
+        # https://github.com/RascalSoftware/RasCAL-2/issues/15
         self.mdi.tileSubWindows()
         self.startup_dlg = self.takeCentralWidget()
         self.setCentralWidget(self.mdi)

--- a/rascal2/ui/view.py
+++ b/rascal2/ui/view.py
@@ -38,10 +38,10 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.controls_widget = QtWidgets.QWidget()
         self.project_widget = QtWidgets.QWidget()
 
-        self.createActions()
-        self.createMenus()
-        self.createToolBar()
-        self.createStatusBar()
+        self.create_actions()
+        self.create_menus()
+        self.create_toolbar()
+        self.create_status_bar()
 
         self.setMinimumSize(1024, 900)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)

--- a/rascal2/widgets/startup_widget.py
+++ b/rascal2/widgets/startup_widget.py
@@ -78,7 +78,7 @@ class StartUpWidget(QtWidgets.QWidget):
         """
         self.new_project_button = QtWidgets.QPushButton(self)
         self.new_project_button.setIcon(QtGui.QIcon(path_for("create.png")))
-        self.new_project_button.clicked.connect(self.parent().showProjectDialog)
+        self.new_project_button.clicked.connect(self.parent().show_project_dialog)
         self.new_project_button.setStyleSheet(self._button_style)
 
         self.import_project_button = QtWidgets.QPushButton(self)

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -7,7 +7,7 @@ from rascal2.dialogs.project_dialog import ProjectDialog
 
 
 class MockPresenter(QtWidgets.QMainWindow):
-    def createProject(self, name: str, folder: str):
+    def create_project(self, name: str, folder: str):
         pass
 
 
@@ -17,7 +17,7 @@ class MockParentWindow(QtWidgets.QMainWindow):
         self.presenter = MockPresenter()
         self.toolbar = self.addToolBar("ToolBar")
         self.toolbar.setEnabled(False)
-        self.showProjectDialog = MagicMock()
+        self.show_project_dialog = MagicMock()
 
 
 @pytest.fixture
@@ -90,7 +90,7 @@ def test_inline_error_msgs(mock_listdir, setup_project_dialog_widget):
 
 
 @patch("os.listdir")
-@patch.object(MockPresenter, "createProject")
+@patch.object(MockPresenter, "create_project")
 def test_create_button(mock_create_project, mock_listdir, setup_project_dialog_widget):
     """
     Tests create button on the ProjectDialog class.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,7 +8,7 @@ def test_create_project():
     assert model.results is None
     assert model.save_path == ""
 
-    model.createProject("Test", "C:/test")
+    model.create_project("Test", "C:/test")
 
     assert model.project.name == "Test"
     assert model.controls is not None

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -36,7 +36,7 @@ def test_integration(qt_application, make_main_window):
     window = make_main_window()
     window.show()
 
-    window.setupMDI()
+    window.setup_mdi()
     names = [win.windowTitle() for win in window.mdi.subWindowList()]
     # QMDIArea is first in last out hence the reversed list
     assert names == ["Fitting Controls", "Terminal", "Project", "Plots"]

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -27,8 +27,8 @@ def test_startup_widget_initial_state(setup_startup_widget):
 
 def test_show_project_dialog_called(setup_startup_widget):
     """
-    Tests the showProjectDialog method is called once.
+    Tests the show_project_dialog method is called once.
     """
     startup_widget, parent = setup_startup_widget
     startup_widget.new_project_button.click()
-    parent.showProjectDialog.assert_called_once()
+    parent.show_project_dialog.assert_called_once()


### PR DESCRIPTION
Fixes #24 by standardising all method names to snake_case and adding [pep8-naming](https://docs.astral.sh/ruff/rules/#pep8-naming-n) to the Ruff rules. Note that when overriding a PyQt function, you will need to add the function to `extend-ignore-names` in pyproject.toml.