### PR TITLE
Bumped RATapi version and removed `resampleParams`

### DIFF
--- a/rascal2/widgets/controls.py
+++ b/rascal2/widgets/controls.py
@@ -93,9 +93,6 @@ class ControlsWidget(QtWidgets.QWidget):
         # add fit settings for each procedure
         for procedure in Procedures:
             proc_settings = [f for f in fields.get(procedure, []) if f != "procedure"]
-            # FIXME remove when resampleParams has been split
-            # https://github.com/RascalSoftware/python-RAT/issues/69
-            proc_settings.remove("resampleParams")
             fit_set = FitSettingsWidget(self, proc_settings, self.presenter)
             self.fit_settings_layout.addWidget(fit_set)
 
@@ -173,9 +170,7 @@ class ControlsWidget(QtWidgets.QWidget):
         self.presenter.edit_controls("procedure", procedure)
         # synchronise common fields between procedures
         for field in common_fields:
-            # FIXME remove resampleparams when fixed
-            # https://github.com/RascalSoftware/RasCAL-2/issues/9
-            if field not in ["procedure", "resampleParams"]:
+            if field not in ["procedure"]:
                 self.fit_settings_layout.currentWidget().update_data(field)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyInstaller==6.9.0
 PyQt6==6.7.0
 PyQt6-Qt6==6.7.2
-RATapi==0.0.0.dev1
+RATapi==0.0.0.dev2
 pydantic==2.8.2

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -97,7 +97,7 @@ def test_procedure_select(controls_widget, procedure):
     wg.procedure_dropdown.setCurrentText(procedure)
     current_fit_set = wg.fit_settings_layout.currentWidget()
     for setting in fields[procedure]:
-        if setting not in ["procedure", "resampleParams"]:
+        if setting not in ["procedure"]:
             assert setting in list(current_fit_set.rows.keys())
 
 


### PR DESCRIPTION
Bumps the RATapi version and removes workarounds related to `resampleParams` now that `resampleParams` has been removed from the API.