### PR TITLE
Makes AdaptiveDoubleSpinBox less erratic

### DIFF
--- a/rascal2/widgets/inputs.py
+++ b/rascal2/widgets/inputs.py
@@ -103,7 +103,7 @@ class AdaptiveDoubleSpinBox(QtWidgets.QDoubleSpinBox):
             The string displayed on the spinbox.
 
         """
-        return f"{value:.{self.decimals()}g}"
+        return f"{round(value, self.decimals()):.{self.decimals()}g}"
 
     def validate(self, input, pos) -> tuple[QtGui.QValidator.State, str, int]:
         """Validate a string written into the spinbox.


### PR DESCRIPTION
Fixes #32. It turns out that when you click up and down, the `self.decimals()` property doesn't change even if the actual value is being shown at higher precision (as it was in the `AdaptiveDoubleSpinBox`), so we can ensure the displayed value is rounded to what we expect.