### PR TITLE
Refactored validated input widgets to be more extensible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ version = {attr = "rascal2.RASCAL2_VERSION"}
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "UP", "B", "SIM", "I", "N", "TD003"]
+select = ["E", "F", "UP", "B", "SIM", "I", "N", "TD003", "A"]
 ignore = ["SIM108", "N817"]
 
 [tool.ruff.lint.flake8-pytest-style]

--- a/rascal2/core/settings.py
+++ b/rascal2/core/settings.py
@@ -54,7 +54,7 @@ class LogLevels(IntEnum):
 
     Debug = logging.DEBUG
     Info = logging.INFO
-    Warning = logging.WARNING
+    Warn = logging.WARNING
     Error = logging.ERROR
     Critical = logging.CRITICAL
 
@@ -62,7 +62,7 @@ class LogLevels(IntEnum):
         names = {
             LogLevels.Debug: "DEBUG",
             LogLevels.Info: "INFO",
-            LogLevels.Warning: "WARNING",
+            LogLevels.Warn: "WARNING",
             LogLevels.Error: "ERROR",
             LogLevels.Critical: "CRITICAL",
         }

--- a/rascal2/dialogs/settings_dialog.py
+++ b/rascal2/dialogs/settings_dialog.py
@@ -1,7 +1,7 @@
 from PyQt6 import QtCore, QtWidgets
 
 from rascal2.core.settings import Settings, SettingsGroups, delete_local_settings
-from rascal2.widgets.inputs import ValidatedInputWidget
+from rascal2.widgets.inputs import get_validated_input
 
 
 class SettingsDialog(QtWidgets.QDialog):
@@ -84,7 +84,7 @@ class SettingsTab(QtWidgets.QWidget):
         for i, setting in enumerate(group_settings):
             label_text = setting.replace("_", " ").title()
             tab_layout.addWidget(QtWidgets.QLabel(label_text), i, 0)
-            self.widgets[setting] = ValidatedInputWidget(field_info[setting])
+            self.widgets[setting] = get_validated_input(field_info[setting])
             try:
                 self.widgets[setting].set_data(getattr(self.settings, setting))
             except TypeError:

--- a/rascal2/widgets/__init__.py
+++ b/rascal2/widgets/__init__.py
@@ -1,5 +1,5 @@
 from rascal2.widgets.controls import ControlsWidget
-from rascal2.widgets.inputs import AdaptiveDoubleSpinBox, ValidatedInputWidget
+from rascal2.widgets.inputs import AdaptiveDoubleSpinBox, get_validated_input
 from rascal2.widgets.terminal import TerminalWidget
 
-__all__ = ["ControlsWidget", "TerminalWidget", "ValidatedInputWidget", "AdaptiveDoubleSpinBox"]
+__all__ = ["ControlsWidget", "AdaptiveDoubleSpinBox", "get_validated_input", "TerminalWidget"]

--- a/rascal2/widgets/controls.py
+++ b/rascal2/widgets/controls.py
@@ -8,7 +8,7 @@ from RATapi.controls import common_fields, fields
 from RATapi.utils.enums import Procedures
 
 from rascal2.config import path_for
-from rascal2.widgets.inputs import ValidatedInputWidget
+from rascal2.widgets.inputs import get_validated_input
 
 
 class ControlsWidget(QtWidgets.QWidget):
@@ -196,7 +196,7 @@ class FitSettingsWidget(QtWidgets.QWidget):
         controls_fields = self.get_controls_attribute("model_fields")
         for i, setting in enumerate(settings):
             field_info = controls_fields[setting]
-            self.rows[setting] = ValidatedInputWidget(field_info)
+            self.rows[setting] = get_validated_input(field_info)
             self.datasetter[setting] = self.create_model_data_setter(setting)
             self.rows[setting].edited_signal.connect(self.datasetter[setting])
             label = QtWidgets.QLabel(setting)

--- a/rascal2/widgets/inputs.py
+++ b/rascal2/widgets/inputs.py
@@ -29,8 +29,8 @@ def get_validated_input(field_info: FieldInfo) -> QtWidgets.QWidget:
         Enum: EnumInputWidget,
     }
 
-    for type, widget in class_widgets.items():
-        if issubclass(field_info.annotation, type):
+    for input_type, widget in class_widgets.items():
+        if issubclass(field_info.annotation, input_type):
             return widget(field_info)
 
     return BaseInputWidget(field_info)
@@ -183,14 +183,14 @@ class AdaptiveDoubleSpinBox(QtWidgets.QDoubleSpinBox):
         """
         return f"{round(value, self.decimals()):.{self.decimals()}g}"
 
-    def validate(self, input, pos) -> tuple[QtGui.QValidator.State, str, int]:
+    def validate(self, input_text, pos) -> tuple[QtGui.QValidator.State, str, int]:
         """Validate a string written into the spinbox.
 
         Override of QtWidgets.QDoubleSpinBox.validate.
 
         Parameters
         ----------
-        input : str
+        input_text : str
             The string written into the spinbox.
         pos : int
             The current cursor position.
@@ -201,13 +201,13 @@ class AdaptiveDoubleSpinBox(QtWidgets.QDoubleSpinBox):
             The validation state of the input, the input string, and position.
 
         """
-        if "e" in input:
+        if "e" in input_text:
             try:
-                self.setDecimals(-int(input.split("e")[-1]))
-                return (QtGui.QValidator.State.Acceptable, input, pos)
+                self.setDecimals(-int(input_text.split("e")[-1]))
+                return (QtGui.QValidator.State.Acceptable, input_text, pos)
             except ValueError:
-                return (QtGui.QValidator.State.Intermediate, input, pos)
-        if "." in input and len(input.split(".")[-1]) != self.decimals():
-            self.setDecimals(len(input.split(".")[-1]))
-            return (QtGui.QValidator.State.Acceptable, input, pos)
-        return super().validate(input, pos)
+                return (QtGui.QValidator.State.Intermediate, input_text, pos)
+        if "." in input_text and len(input_text.split(".")[-1]) != self.decimals():
+            self.setDecimals(len(input_text.split(".")[-1]))
+            return (QtGui.QValidator.State.Acceptable, input_text, pos)
+        return super().validate(input_text, pos)

--- a/rascal2/widgets/inputs.py
+++ b/rascal2/widgets/inputs.py
@@ -50,13 +50,17 @@ class BaseInputWidget(QtWidgets.QWidget):
 
     """
 
+    data_getter = "text"
+    data_setter = "setText"
+    edit_signal = "textChanged"
+
     def __init__(self, field_info: FieldInfo, parent=None):
         super().__init__(parent=parent)
 
-        self.editor = self.create_editor(field_info)
-        self.get_data = self.data_getter()
-        self.set_data = self.data_setter()
-        self.edited_signal = self.edit_signal()
+        self.editor: QtWidgets.QWidget = self.create_editor(field_info)
+        self.get_data: Callable = getattr(self.editor, self.data_getter)
+        self.set_data: Callable = getattr(self.editor, self.data_setter)
+        self.edited_signal: QtCore.pyqtSignal = getattr(self.editor, self.edit_signal)
 
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.editor)
@@ -81,21 +85,13 @@ class BaseInputWidget(QtWidgets.QWidget):
         """
         return QtWidgets.QLineEdit(self)
 
-    def data_getter(self) -> Callable:
-        """The data getter function for the editor."""
-        return self.editor.text
-
-    def data_setter(self) -> Callable:
-        """The data setter function for the editor."""
-        return self.editor.setText
-
-    def edit_signal(self) -> QtCore.pyqtSignal:
-        """The signal produced when the editor data changes."""
-        return self.editor.textChanged
-
 
 class IntInputWidget(BaseInputWidget):
     """Input widget for integer data with optional minimum and maximum values."""
+
+    data_getter = "value"
+    data_setter = "setValue"
+    edit_signal = "editingFinished"
 
     def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
         editor = QtWidgets.QSpinBox(self)
@@ -111,18 +107,13 @@ class IntInputWidget(BaseInputWidget):
 
         return editor
 
-    def data_getter(self) -> Callable:
-        return self.editor.value
-
-    def data_setter(self) -> Callable:
-        return self.editor.setValue
-
-    def edit_signal(self) -> QtCore.pyqtSignal:
-        return self.editor.editingFinished
-
 
 class FloatInputWidget(BaseInputWidget):
     """Input widget for float data with optional minimum and maximum values."""
+
+    data_getter = "value"
+    data_setter = "setValue"
+    edit_signal = "editingFinished"
 
     def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
         editor = AdaptiveDoubleSpinBox(self)
@@ -140,49 +131,30 @@ class FloatInputWidget(BaseInputWidget):
 
         return editor
 
-    def data_getter(self) -> Callable:
-        return self.editor.value
-
-    def data_setter(self) -> Callable:
-        return self.editor.setValue
-
-    def edit_signal(self) -> QtCore.pyqtSignal:
-        return self.editor.editingFinished
-
 
 class BoolInputWidget(BaseInputWidget):
     """Input widget for boolean data."""
 
+    data_getter = "isChecked"
+    data_setter = "setChecked"
+    edit_signal = "checkStateChanged"
+
     def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
         return QtWidgets.QCheckBox(self)
-
-    def data_getter(self) -> Callable:
-        return self.editor.isChecked
-
-    def data_setter(self) -> Callable:
-        return self.editor.setChecked
-
-    def edit_signal(self) -> QtCore.pyqtSignal:
-        return self.editor.checkStateChanged
 
 
 class EnumInputWidget(BaseInputWidget):
     """Input widget for Enums."""
+
+    data_getter = "currentText"
+    data_setter = "setCurrentText"
+    edit_signal = "currentTextChanged"
 
     def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
         editor = QtWidgets.QComboBox(self)
         editor.addItems(str(e) for e in field_info.annotation)
 
         return editor
-
-    def data_getter(self) -> Callable:
-        return self.editor.currentText
-
-    def data_setter(self) -> Callable:
-        return self.editor.setCurrentText
-
-    def edit_signal(self) -> QtCore.pyqtSignal:
-        return self.editor.currentTextChanged
 
 
 class AdaptiveDoubleSpinBox(QtWidgets.QDoubleSpinBox):

--- a/rascal2/widgets/inputs.py
+++ b/rascal2/widgets/inputs.py
@@ -1,4 +1,4 @@
-"""Widget for validated user inputs."""
+"""Widgets for validated user inputs."""
 
 from enum import Enum
 from math import floor, log10
@@ -8,75 +8,181 @@ from pydantic.fields import FieldInfo
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 
-class ValidatedInputWidget(QtWidgets.QWidget):
-    """Value input generated from Pydantic field info.
+def get_validated_input(field_info: FieldInfo) -> QtWidgets.QWidget:
+    """Get a validated input widget from Pydantic field info.
 
     Parameters
     ----------
-    field_info: FieldInfo
+    field_info : FieldInfo
+        The Pydantic field info for the field.
+
+    Returns
+    -------
+    QtWidgets.QWidget
+        The validated input widget for the field.
+
+    """
+    class_widgets = {
+        bool: BoolInputWidget,
+        int: IntInputWidget,
+        float: FloatInputWidget,
+        Enum: EnumInputWidget,
+    }
+
+    for type, widget in class_widgets.items():
+        if issubclass(field_info.annotation, type):
+            return widget(field_info)
+
+    return BaseInputWidget(field_info)
+
+
+class BaseInputWidget(QtWidgets.QWidget):
+    """Base class for input generated from Pydantic field info.
+
+    This base class is used for unrecognised types.
+
+    Parameters
+    ----------
+    field_info : FieldInfo
         The Pydantic field info for the input.
-    parent: QWidget or None, default None
+    parent : QWidget or None, default None
         The parent widget of this widget.
 
     """
 
     def __init__(self, field_info: FieldInfo, parent=None):
         super().__init__(parent=parent)
+
+        self.editor = self.create_editor(field_info)
+        self.get_data = self.data_getter()
+        self.set_data = self.data_setter()
+        self.edited_signal = self.edit_signal()
+
         layout = QtWidgets.QVBoxLayout()
-        # editor_data and change_editor_data are set to the getter and setter
-        # methods for the actual editor inside the widget
-        self.get_data: Callable
-        self.set_data: Callable
-        self.edited_signal: QtCore.pyqtSignal
-
-        # widget, getter, setter and change signal for different datatypes
-        editor_types = {
-            int: (QtWidgets.QSpinBox, "value", "setValue", "editingFinished"),
-            float: (AdaptiveDoubleSpinBox, "value", "setValue", "editingFinished"),
-            bool: (QtWidgets.QCheckBox, "isChecked", "setChecked", "checkStateChanged"),
-        }
-        defaults = (QtWidgets.QLineEdit, "text", "setText", "textChanged")
-
-        if issubclass(field_info.annotation, Enum):
-            self.editor = QtWidgets.QComboBox(self)
-            self.editor.addItems(str(e) for e in field_info.annotation)
-            self.get_data = self.editor.currentText
-            self.set_data = self.editor.setCurrentText
-            self.edited_signal = self.editor.currentTextChanged
-        else:
-            editor, getter, setter, signal = editor_types.get(field_info.annotation, defaults)
-            self.editor = editor(self)
-            self.get_data = getattr(self.editor, getter)
-            self.set_data = getattr(self.editor, setter)
-            self.edited_signal = getattr(self.editor, signal)
-        if isinstance(self.editor, QtWidgets.QSpinBox):
-            for item in field_info.metadata:
-                if hasattr(item, "ge"):
-                    self.editor.setMinimum(item.ge)
-                if hasattr(item, "gt"):
-                    self.editor.setMinimum(item.gt + 1)
-                if hasattr(item, "le"):
-                    self.editor.setMaximum(item.le)
-                if hasattr(item, "lt"):
-                    self.editor.setMaximum(item.lt - 1)
-        elif isinstance(self.editor, AdaptiveDoubleSpinBox):
-            for item in field_info.metadata:
-                for attr in ["ge", "gt"]:
-                    if hasattr(item, attr):
-                        self.editor.setMinimum(getattr(item, attr))
-                for attr in ["le", "lt"]:
-                    if hasattr(item, attr):
-                        self.editor.setMaximum(getattr(item, attr))
-            # if no default exists, field_info.default is PydanticUndefined not a nonexistent attribute
-            if isinstance(field_info.default, (int, float)) and field_info.default > 0:
-                # set default decimals to order of magnitude of default value
-                self.editor.setDecimals(-floor(log10(abs(field_info.default))))
-
         layout.addWidget(self.editor)
         layout.setContentsMargins(5, 0, 0, 0)
 
         self.setLayout(layout)
         self.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed)
+
+    def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
+        """Create the relevant editor for the field information.
+
+        Parameters
+        ----------
+        field_info : FieldInfo
+            The Pydantic field information for the input.
+
+        Returns
+        -------
+        QtWidgets.QWidget
+            A widget which allows restricted input based on the field information.
+
+        """
+        return QtWidgets.QLineEdit(self)
+
+    def data_getter(self) -> Callable:
+        """The data getter function for the editor."""
+        return self.editor.text
+
+    def data_setter(self) -> Callable:
+        """The data setter function for the editor."""
+        return self.editor.setText
+
+    def edit_signal(self) -> QtCore.pyqtSignal:
+        """The signal produced when the editor data changes."""
+        return self.editor.textChanged
+
+
+class IntInputWidget(BaseInputWidget):
+    """Input widget for integer data with optional minimum and maximum values."""
+
+    def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
+        editor = QtWidgets.QSpinBox(self)
+        for item in field_info.metadata:
+            if hasattr(item, "ge"):
+                editor.setMinimum(item.ge)
+            if hasattr(item, "gt"):
+                editor.setMinimum(item.gt + 1)
+            if hasattr(item, "le"):
+                editor.setMaximum(item.le)
+            if hasattr(item, "lt"):
+                editor.setMaximum(item.lt - 1)
+
+        return editor
+
+    def data_getter(self) -> Callable:
+        return self.editor.value
+
+    def data_setter(self) -> Callable:
+        return self.editor.setValue
+
+    def edit_signal(self) -> QtCore.pyqtSignal:
+        return self.editor.editingFinished
+
+
+class FloatInputWidget(BaseInputWidget):
+    """Input widget for float data with optional minimum and maximum values."""
+
+    def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
+        editor = AdaptiveDoubleSpinBox(self)
+        for item in field_info.metadata:
+            for attr in ["ge", "gt"]:
+                if hasattr(item, attr):
+                    editor.setMinimum(getattr(item, attr))
+            for attr in ["le", "lt"]:
+                if hasattr(item, attr):
+                    editor.setMaximum(getattr(item, attr))
+        # if no default exists, field_info.default is PydanticUndefined not a nonexistent attribute
+        if isinstance(field_info.default, (int, float)) and field_info.default > 0:
+            # set default decimals to order of magnitude of default value
+            editor.setDecimals(-floor(log10(abs(field_info.default))))
+
+        return editor
+
+    def data_getter(self) -> Callable:
+        return self.editor.value
+
+    def data_setter(self) -> Callable:
+        return self.editor.setValue
+
+    def edit_signal(self) -> QtCore.pyqtSignal:
+        return self.editor.editingFinished
+
+
+class BoolInputWidget(BaseInputWidget):
+    """Input widget for boolean data."""
+
+    def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
+        return QtWidgets.QCheckBox(self)
+
+    def data_getter(self) -> Callable:
+        return self.editor.isChecked
+
+    def data_setter(self) -> Callable:
+        return self.editor.setChecked
+
+    def edit_signal(self) -> QtCore.pyqtSignal:
+        return self.editor.checkStateChanged
+
+
+class EnumInputWidget(BaseInputWidget):
+    """Input widget for Enums."""
+
+    def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
+        editor = QtWidgets.QComboBox(self)
+        editor.addItems(str(e) for e in field_info.annotation)
+
+        return editor
+
+    def data_getter(self) -> Callable:
+        return self.editor.currentText
+
+    def data_setter(self) -> Callable:
+        return self.editor.setCurrentText
+
+    def edit_signal(self) -> QtCore.pyqtSignal:
+        return self.editor.currentTextChanged
 
 
 class AdaptiveDoubleSpinBox(QtWidgets.QDoubleSpinBox):

--- a/tests/dialogs/test_project_dialog.py
+++ b/tests/dialogs/test_project_dialog.py
@@ -211,7 +211,7 @@ def test_verify_folder(contents, has_project):
 def test_load_invalid_json():
     """If project loading produces an error (which it does for invalid JSON), raise that error in the textbox."""
 
-    def error(dir):
+    def error(ignored_dir):
         raise ValueError("Project load error!")
 
     view.presenter.load_project = error

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic.fields import FieldInfo
 from PyQt6 import QtWidgets
 
-from rascal2.widgets import AdaptiveDoubleSpinBox, ValidatedInputWidget
+from rascal2.widgets import AdaptiveDoubleSpinBox, get_validated_input
 
 
 class MyEnum(StrEnum):
@@ -28,7 +28,7 @@ class MyEnum(StrEnum):
 def test_editor_type(field_info, expected_type, example_data):
     """Test that the editor type is as expected, and can be read and written."""
 
-    widget = ValidatedInputWidget(field_info)
+    widget = get_validated_input(field_info)
     assert isinstance(widget.editor, expected_type)
     widget.set_data(example_data)
     assert widget.get_data() == example_data


### PR DESCRIPTION
This PR refactors validated input widgets to a more object-oriented system that makes them easier to extend and change. Fixes #41.

To add a new input widget, the user should create a subclass of `BaseInputWidget` which has one method and three class attributes defined:

```python
class MyInputWidget(BaseInputWidget):
    """My special input widget."""
    
    data_getter: str = "myGetter"  # data getter method for the editor
    data_setter: str = "mySetter"  # data setter method for the editor
    edit_signal: str = "editedSignal"  # method for signal editor produces when changed

    def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
        """Method that creates the editor widget from Pydantic field info."""
        # whatever goes here...
```

and then register the widget and its relevant type in the `class_widgets` dictionary in a new `get_validated_input` function. This will produce an input widget which has methods `editor` for its editor, `get_data` for its data getter, `set_data` for its data setter and `edited_signal` for its change signal as before.

Accessing the validated input widgets is almost the same: we just change `widget = ValidatedInputWidget(field_info)` to `widget = get_validated_input(field_info)`.

This means that the creation of editors is more encapsulated for each type, rather than the previous system of "just get the type of widget from the data type and then use this big if/elif/elif... block to sort out the relevant validation"