### PR TITLE
Fix for strategy enum bug

### DIFF
--- a/rascal2/widgets/inputs.py
+++ b/rascal2/widgets/inputs.py
@@ -146,13 +146,14 @@ class BoolInputWidget(BaseInputWidget):
 class EnumInputWidget(BaseInputWidget):
     """Input widget for Enums."""
 
-    data_getter = "currentText"
+    data_getter = "currentData"
     data_setter = "setCurrentText"
     edit_signal = "currentTextChanged"
 
     def create_editor(self, field_info: FieldInfo) -> QtWidgets.QWidget:
         editor = QtWidgets.QComboBox(self)
-        editor.addItems(str(e) for e in field_info.annotation)
+        for e in field_info.annotation:
+            editor.addItem(str(e), e)
 
         return editor
 


### PR DESCRIPTION
After my previous PR, runs are failing at `controls.strategy = int(input_controls.strategy) ` because we are using  `vars(self.controls).update(new_values)` to set the control the enum string is not converted to an enum.  This fix ensures an enum is always passed out of the controls widget. 

Might be worth fixing this in python-RAT so it does not fail if strategy is a string 