### PR TITLE
Adds saving and loading of project files

### DIFF
--- a/rascal2/config.py
+++ b/rascal2/config.py
@@ -93,14 +93,22 @@ def setup_logging(log_path: str | PathLike, terminal, level: int = logging.INFO)
     return logger
 
 
-def log_uncaught_exceptions(exc_type, exc_value, exc_traceback):
-    """Qt slots swallows exceptions but this ensures exceptions are logged"""
+def get_logger():
+    """Get the RasCAL logger, and set up a backup logger if it hasn't been set up yet."""
     logger = logging.getLogger("rascal_log")
     if not logger.handlers:
         # Backup in case the crash happens before the local logger setup
         path = pathlib.Path(get_global_settings().fileName()).parent
         path.mkdir(parents=True, exist_ok=True)
-        logger.addHandler(logging.FileHandler(path / "crash.log"))
+        logger.addHandler(logging.FileHandler(path / "rascal.log"))
+
+    return logger
+
+
+def log_uncaught_exceptions(exc_type, exc_value, exc_traceback):
+    """Qt slots swallows exceptions but this ensures exceptions are logged"""
+    logger = get_logger()
+    logger.addHandler(logging.StreamHandler(stream=sys.stderr))  # print emergency crashes to terminal
     logger.critical("An unhandled exception occurred!", exc_info=(exc_type, exc_value, exc_traceback))
     logging.shutdown()
     sys.exit(1)

--- a/rascal2/dialogs/project_dialog.py
+++ b/rascal2/dialogs/project_dialog.py
@@ -7,7 +7,7 @@ from rascal2.config import path_for
 from rascal2.core.settings import update_recent_projects
 
 # global variable for required project files
-PROJECT_FILES = ["controls.json"]
+PROJECT_FILES = ["controls.json", "project.json"]
 
 
 class StartupDialog(QtWidgets.QDialog):

--- a/rascal2/ui/model.py
+++ b/rascal2/ui/model.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Union
 
@@ -77,8 +78,8 @@ class MainWindowModel(QtCore.QObject):
         controls_file = Path(self.save_path, "controls.json")
         controls_file.write_text(self.controls.model_dump_json())
 
-        # TODO add saving `Project` once this is possible
-        # https://github.com/RascalSoftware/python-RAT/issues/76
+        project_file = Path(self.save_path, "project.json")
+        project_file.write_text(RAT.utils.convert.project_to_json(self.project))
 
     def load_project(self, load_path: str):
         """Load a project from a project folder.
@@ -103,9 +104,14 @@ class MainWindowModel(QtCore.QObject):
                 "It may contain invalid parameter values or be invalid JSON."
             ) from err
 
-        # TODO add saving `Project` once this is possible
-        # https://github.com/RascalSoftware/python-RAT/issues/76
-        self.project = RAT.Project()
+        project_file = Path(load_path, "project.json")
+        try:
+            self.project = RAT.utils.convert.project_from_json(project_file.read_text())
+        except JSONDecodeError as err:
+            raise ValueError("The project.json file for this project contains invalid JSON.") from err
+        except (KeyError, ValueError) as err:
+            raise ValueError("The project.json file for this project is not valid.") from err
+
         self.save_path = load_path
 
     def load_r1_project(self, load_path: str):

--- a/rascal2/ui/model.py
+++ b/rascal2/ui/model.py
@@ -97,7 +97,7 @@ class MainWindowModel(QtCore.QObject):
         """
         controls_file = Path(load_path, "controls.json")
         try:
-            self.controls = RAT.Controls.model_validate_json(controls_file.read_text())
+            controls = RAT.Controls.model_validate_json(controls_file.read_text())
         except ValueError as err:
             raise ValueError(
                 "The controls.json file for this project is not valid.\n"
@@ -106,12 +106,14 @@ class MainWindowModel(QtCore.QObject):
 
         project_file = Path(load_path, "project.json")
         try:
-            self.project = RAT.utils.convert.project_from_json(project_file.read_text())
+            project = RAT.utils.convert.project_from_json(project_file.read_text())
         except JSONDecodeError as err:
             raise ValueError("The project.json file for this project contains invalid JSON.") from err
         except (KeyError, ValueError) as err:
             raise ValueError("The project.json file for this project is not valid.") from err
 
+        self.controls = controls
+        self.project = project
         self.save_path = load_path
 
     def load_r1_project(self, load_path: str):

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -48,7 +48,11 @@ class MainWindowPresenter:
             The path from which to load the project.
 
         """
-        self.model.load_project(load_path)
+        try:
+            self.model.load_project(load_path)
+        except ValueError as err:
+            self.view.logging.error(f"Failed to load project at path {load_path}:\n {err}")
+            raise err  # so that it can be captured by the widget
         self.initialise_ui(self.model.project.name, load_path)
 
     def load_r1_project(self, load_path: str):

--- a/rascal2/ui/view.py
+++ b/rascal2/ui/view.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from rascal2.config import path_for, setup_logging, setup_settings
+from rascal2.config import get_logger, path_for, setup_logging, setup_settings
 from rascal2.core.settings import MDIGeometries, Settings
 from rascal2.dialogs.project_dialog import PROJECT_FILES, LoadDialog, LoadR1Dialog, NewProjectDialog, StartupDialog
 from rascal2.dialogs.settings_dialog import SettingsDialog
@@ -49,6 +49,7 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self.settings = Settings()
+        self.logging = get_logger()
         self.startup_dlg = StartUpWidget(self)
         self.setCentralWidget(self.startup_dlg)
 

--- a/tests/dialogs/test_project_dialog.py
+++ b/tests/dialogs/test_project_dialog.py
@@ -188,8 +188,8 @@ def test_recent_projects(recent):
     [
         ([], False),
         (["file.txt, settings.json", "data/"], False),
-        (["controls.json"], True),
-        (["controls.json", "logs/", "plots/", ".otherfile"], True),
+        (["controls.json", "project.json"], True),
+        (["controls.json", "project.json", "logs/", "plots/", ".otherfile"], True),
     ],
 )
 def test_verify_folder(contents, has_project):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from RATapi import Controls
+from RATapi.utils.enums import Calculations
 
 from rascal2.ui.model import MainWindowModel
 
@@ -26,15 +27,19 @@ def test_create_project():
 
 def test_save_project():
     model = MainWindowModel()
+    model.project = Project(calculation="domains", name="test project")
     model.controls = Controls(procedure="dream", resampleMinAngle=0.5)
     with TemporaryDirectory() as tmpdir:
         model.save_path = tmpdir
         model.save_project()
 
         controls = Path(tmpdir, "controls.json").read_text()
+        project = Path(tmpdir, "project.json").read_text()
 
     assert '"resampleMinAngle":0.5' in controls
     assert '"procedure":"dream"' in controls
+    assert '"name":"test project"' in project
+    assert '"calculation":"domains' in project
 
 
 def test_load_project():
@@ -43,9 +48,12 @@ def test_load_project():
 
     with TemporaryDirectory() as tmpdir:
         Path(tmpdir, "controls.json").write_text('{"procedure":"dream","resampleMinAngle":0.5}')
+        Path(tmpdir, "project.json").write_text('{"name":"test project","calculation":"domains"}')
         model.load_project(tmpdir)
 
     assert model.controls == Controls(procedure="dream", resampleMinAngle=0.5)
+    assert model.project.calculation == Calculations.Domains
+    assert model.project.name == "test project"
 
 
 @patch("RATapi.utils.convert.r1_to_project_class")
@@ -59,7 +67,7 @@ def test_load_r1_project(mock_r1_class):
 
 
 @pytest.mark.parametrize("bad_json", ['{"field1":3', '{"procedure":"fry eggs"}'])
-def test_load_project_error(bad_json):
+def test_load_controls_error(bad_json):
     """The project load function should raise an error if the controls JSON is invalid or the parameters are invalid."""
     model = MainWindowModel()
 
@@ -70,4 +78,30 @@ def test_load_project_error(bad_json):
     ):
         with TemporaryDirectory() as tmpdir:
             Path(tmpdir, "controls.json").write_text(bad_json)
+            model.load_project(tmpdir)
+
+@pytest.mark.parametrize("bad_json", ['{"calculation":"Do}', '{i"m not a good project file'])
+def test_load_project_decode_error(bad_json):
+    """The project load function should raise an error if the project JSON is invalid JSON."""
+    model = MainWindowModel()
+
+    with pytest.raises(  # noqa (for nested with's: pytest.raises breaks if not by itself)
+        ValueError,
+        match="The project.json file for this project contains invalid JSON."
+    ):
+        with TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "project.json").write_text(bad_json)
+            model.load_project(tmpdir)
+
+@pytest.mark.parametrize("bad_json", ['{"calculation":"guessing"}', '{"parameters":[{"name":"parameter 1","thickness":0.51}]}'])
+def test_load_project_value_error(bad_json):
+    """The project load function should raise an error if the values are not valid."""
+    model = MainWindowModel()
+
+    with pytest.raises(  # noqa (for nested with's: pytest.raises breaks if not by itself)
+        ValueError,
+        match="The project.json file for this project is not valid."
+    ):
+        with TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "project.json").write_text(bad_json)
             model.load_project(tmpdir)


### PR DESCRIPTION
Fixes #51 by adding the project file to the save and load functions. 

Here's an example project that can be used to test loading (it's the DSPC standard layers example project)
[standard_layers.zip](https://github.com/user-attachments/files/17659050/standard_layers.zip)
