### PR TITLE
Fixes obsolete `libgl1-mesa-glx` package and updates ruff formatting

### DIFF
--- a/.github/actions/linux/action.yaml
+++ b/.github/actions/linux/action.yaml
@@ -9,7 +9,7 @@ runs:
     shell: bash -l {0}
     run: |
       sudo apt update
-      sudo apt install xvfb libqt5x11extras5 libgl1-mesa-glx '^libxcb.*-dev'
+      sudo apt install xvfb libqt5x11extras5 libgl1 libglx-mesa0 '^libxcb.*-dev'
   - name: Install RasCAL2
     shell: bash -l {0}
     run: pip install .

--- a/rascal2/widgets/project/project.py
+++ b/rascal2/widgets/project/project.py
@@ -326,11 +326,11 @@ class ProjectWidget(QtWidgets.QWidget):
 
                 if missing_params:
                     noun = "a parameter" if len(missing_params) == 1 else "parameters"
-                    msg = f"Layer '{layer.name}' (row {i+1}) is missing {noun}: {', '.join(missing_params)}"
+                    msg = f"Layer '{layer.name}' (row {i + 1}) is missing {noun}: {', '.join(missing_params)}"
                     errors.append(msg)
                 if invalid_params:
                     noun = "an invalid value" if len(invalid_params) == 1 else "invalid values"
-                    msg = f"Layer '{layer.name}' (row {i+1}) has {noun}: " "{0}".format(
+                    msg = f"Layer '{layer.name}' (row {i + 1}) has {noun}: {{0}}".format(
                         ",\n  ".join(f'"{v}" for parameter {p}' for p, v in invalid_params)
                     )
                     errors.append(msg)

--- a/tests/widgets/project/test_project.py
+++ b/tests/widgets/project/test_project.py
@@ -291,12 +291,12 @@ def test_project_tab_validate_layers(input_params, absorption):
 
         if missing_params:
             noun = "a parameter" if len(missing_params) == 1 else "parameters"
-            msg = f"Layer '{layer.name}' (row {i+1}) is missing {noun}: {', '.join(missing_params)}"
+            msg = f"Layer '{layer.name}' (row {i + 1}) is missing {noun}: {', '.join(missing_params)}"
             expected_err.append(msg)
         if invalid_params:
             noun = "an invalid value" if len(invalid_params) == 1 else "invalid values"
             msg = (
-                f"Layer '{layer.name}' (row {i+1}) has {noun}: "
+                f"Layer '{layer.name}' (row {i + 1}) has {noun}: "
                 f"{', '.join(f'"Invalid Param" for parameter {p}' for p in invalid_params)}"
             )
             expected_err.append(msg)


### PR DESCRIPTION
The `ubuntu-latest` Github runner image was recently updated to Ubuntu 24 (see actions/runner-images#11332). The package `libgl1-mesa-glx` was [made obsolete in Ubuntu 23](https://askubuntu.com/questions/1517352/issues-installing-libgl1-mesa-glx) which means that our Linux action no longer works. This PR replaces them with the correct equivalent packages `libgl1` and `libglx-mesa0`.

This PR also runs `ruff format` for the new formatting options in `ruff` 0.9.