### PR TITLE
Applies python-RAT custom format to pydantic fallback error messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,6 @@ extend-ignore-names = ['allKeys',
                        'showEvent',
                        'sizeHint',
                        'stepBy',
+                       'supportedDropActions',
                        'textFromValue',
                        'valueFromText',]

--- a/rascal2/widgets/delegates.py
+++ b/rascal2/widgets/delegates.py
@@ -128,6 +128,12 @@ class ProjectFieldDelegate(QtWidgets.QStyledItemDelegate):
         widget.addItems(names)
         widget.setCurrentText(index.data(QtCore.Qt.ItemDataRole.DisplayRole))
 
+        # make combobox searchable
+        widget.setEditable(True)
+        widget.setInsertPolicy(widget.InsertPolicy.NoInsert)
+        widget.setFrame(False)
+        widget.completer().setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
+
         return widget
 
     def setEditorData(self, editor: QtWidgets.QWidget, index):

--- a/rascal2/widgets/delegates.py
+++ b/rascal2/widgets/delegates.py
@@ -113,17 +113,18 @@ class ValueSpinBoxDelegate(QtWidgets.QStyledItemDelegate):
         model.setData(index, data, QtCore.Qt.ItemDataRole.EditRole)
 
 
-class ParametersDelegate(QtWidgets.QStyledItemDelegate):
+class ProjectFieldDelegate(QtWidgets.QStyledItemDelegate):
     """Item delegate to choose from existing draft project parameters."""
 
-    def __init__(self, project_widget, parent):
+    def __init__(self, project_widget, field, parent):
         super().__init__(parent)
+        self.field = field
         self.project_widget = project_widget
 
     def createEditor(self, parent, option, index):
         widget = QtWidgets.QComboBox(parent)
-        parameters = self.project_widget.draft_project["parameters"]
-        names = [p.name for p in parameters]
+        items = self.project_widget.draft_project[self.field]
+        names = [item.name for item in items]
         widget.addItems(names)
         widget.setCurrentText(index.data(QtCore.Qt.ItemDataRole.DisplayRole))
 

--- a/rascal2/widgets/project/lists.py
+++ b/rascal2/widgets/project/lists.py
@@ -261,7 +261,9 @@ class StandardLayerModelWidget(QtWidgets.QWidget):
         self.layer_list = QtWidgets.QListView(parent)
         self.layer_list.setModel(self.model)
         if parent.model.domains:
-            self.layer_list.setItemDelegateForColumn(0, ProjectFieldDelegate(parent.project_widget, "domain_contrasts", self))
+            self.layer_list.setItemDelegateForColumn(
+                0, ProjectFieldDelegate(parent.project_widget, "domain_contrasts", self)
+            )
         else:
             self.layer_list.setItemDelegateForColumn(0, ProjectFieldDelegate(parent.project_widget, "layers", self))
         self.layer_list.setDragEnabled(True)

--- a/rascal2/widgets/project/lists.py
+++ b/rascal2/widgets/project/lists.py
@@ -256,7 +256,7 @@ class LayerStringListModel(QtCore.QStringListModel):
 class StandardLayerModelWidget(QtWidgets.QWidget):
     """Widget for standard layer contrast models."""
 
-    def __init__(self, init_list: list[str], parent=None):
+    def __init__(self, init_list: list[str], parent):
         super().__init__(parent)
 
         self.model = LayerStringListModel(init_list, self)
@@ -413,7 +413,6 @@ class ContrastWidget(AbstractProjectListWidget):
         layout = QtWidgets.QVBoxLayout()
         layout.addLayout(top_grid)
         layout.addLayout(settings_row)
-        layout.addStretch()
         layout.addLayout(model_grid)
 
         widget = QtWidgets.QWidget(self)

--- a/rascal2/widgets/project/lists.py
+++ b/rascal2/widgets/project/lists.py
@@ -1,0 +1,397 @@
+"""Tab model/views which are based on a list at the side of the widget."""
+
+from typing import Any, Callable, Generic, TypeVar
+
+import RATapi
+from PyQt6 import QtCore, QtGui, QtWidgets
+from RATapi.utils.enums import BackgroundActions
+
+from rascal2.config import path_for
+from rascal2.widgets.delegates import ProjectFieldDelegate
+
+T = TypeVar("T")
+
+
+class ClassListItemModel(QtCore.QAbstractListModel, Generic[T]):
+    """Item model for a project ClassList field.
+
+    Parameters
+    ----------
+    classlist : ClassList
+        The initial classlist to represent in this model.
+    field : str
+        The name of the field represented by this model.
+    parent : QtWidgets.QWidget
+        The parent widget for the model.
+
+    """
+
+    def __init__(self, classlist: RATapi.ClassList[T], parent: QtWidgets.QWidget):
+        super().__init__(parent)
+        self.parent = parent
+
+        self.classlist = classlist
+        self.item_type = classlist._class_handle
+        self.edit_mode = False
+
+    def rowCount(self, parent=None) -> int:
+        return len(self.classlist)
+
+    def data(self, index, role=QtCore.Qt.ItemDataRole.DisplayRole) -> str:
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
+            row = index.row()
+            return self.classlist[row].name
+
+    def get_item(self, row: int) -> T:
+        """Get an item from the ClassList.
+
+        Parameters
+        ----------
+        row : int
+            The index of the ClassList to get.
+
+        Returns
+        -------
+        T
+            The relevant item from the classlist.
+
+        """
+        return self.classlist[row]
+
+    def set_data(self, row: int, param: str, value: Any):
+        """Set data for an item in the ClassList.
+
+        Parameters
+        ----------
+        row : int
+            The index of the ClassList to get.
+        param : str
+            The parameter of the item to change.
+        value : Any
+            The value to set the parameter to.
+
+        """
+        setattr(self.classlist[row], param, value)
+        self.endResetModel()
+
+    def append_item(self):
+        """Append an item to the ClassList."""
+        self.classlist.append(self.item_type())
+        self.endResetModel()
+
+    def delete_item(self, row: int):
+        """Delete an item in the ClassList.
+
+        Parameters
+        ----------
+        row : int
+            The row containing the item to delete.
+
+        """
+        self.classlist.pop(row)
+        self.endResetModel()
+
+
+class AbstractProjectListWidget(QtWidgets.QWidget):
+    """An abstract base widget for editing items kept in a list."""
+
+    def __init__(self, field: str, parent):
+        super().__init__(parent)
+        self.field = field
+        self.parent = parent
+        self.project_widget = self.parent.parent
+        self.edit_mode = False
+        self.model = None
+
+        layout = QtWidgets.QHBoxLayout()
+
+        item_list = QtWidgets.QVBoxLayout()
+
+        self.list = QtWidgets.QListView(parent)
+        self.list.setSizePolicy(QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+
+        buttons = QtWidgets.QHBoxLayout()
+
+        self.add_button = QtWidgets.QPushButton("+")
+        self.add_button.setHidden(True)
+        self.add_button.pressed.connect(self.append_item)
+        buttons.addWidget(self.add_button)
+
+        self.delete_button = QtWidgets.QPushButton(icon=QtGui.QIcon(path_for("delete.png")))
+        self.delete_button.setHidden(True)
+        self.delete_button.pressed.connect(self.delete_item)
+        buttons.addWidget(self.delete_button)
+
+        item_list.addWidget(self.list)
+        item_list.addLayout(buttons)
+
+        layout.addLayout(item_list)
+
+        self.item_view = QtWidgets.QScrollArea(parent)
+        self.item_view.setWidgetResizable(True)
+        layout.addWidget(self.item_view)
+
+        self.setLayout(layout)
+
+    def update_model(self, classlist):
+        """Update the list model to synchronise with the project field.
+
+        Parameters
+        ----------
+        classlist: RATapi.ClassList
+            The classlist to set in the model.
+
+        """
+        self.model = ClassListItemModel(classlist, self)
+        self.list.setModel(self.model)
+        # this signal changes the current contrast shown in the editor to be the currently highlighted list item
+        self.list.selectionModel().currentChanged.connect(lambda index, _: self.view_stack.setCurrentIndex(index.row()))
+
+        self.update_item_view()
+
+    def update_item_view(self):
+        """Update the item views to correspond with the list model."""
+
+        self.view_stack = QtWidgets.QStackedWidget(self)
+
+        if self.model is not None:
+            # if there are no items, replace the widget with information
+            if self.model.rowCount() == 0:
+                self.view_stack = QtWidgets.QLabel(
+                    "No contrasts are currently defined! Edit the project to add a contrast."
+                )
+                self.view_stack.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+
+            for i in range(0, self.model.rowCount()):
+                if self.edit_mode:
+                    widget = self.create_editor(i)
+                else:
+                    widget = self.create_view(i)
+                self.view_stack.addWidget(widget)
+
+            self.item_view.setWidget(self.view_stack)
+
+    def edit(self):
+        """Update the view to be in edit mode."""
+        self.add_button.setVisible(True)
+        self.delete_button.setVisible(True)
+        self.edit_mode = True
+        self.update_item_view()
+
+    def append_item(self):
+        """Append an item to the model if the model exists."""
+        if self.model is not None:
+            self.model.append_item()
+
+        new_widget_index = self.model.rowCount() - 1
+        # handle if no contrasts currently exist
+        if isinstance(self.view_stack, QtWidgets.QLabel):
+            self.view_stack = QtWidgets.QStackedWidget(self)
+            self.item_view.setWidget(self.view_stack)
+
+        # add contrast viewer/editor to stack without resetting entire stack
+        if self.edit_mode:
+            self.view_stack.addWidget(self.create_editor(new_widget_index))
+        else:
+            self.view_stack.addWidget(self.create_view(new_widget_index))
+
+    def delete_item(self):
+        """Delete the currently selected item."""
+        if self.model is not None:
+            selection_model = self.list.selectionModel()
+            self.model.delete_item(selection_model.currentIndex().row())
+
+        self.update_item_view()
+
+    def create_view(self, i: int) -> QtWidgets.QWidget:
+        """Create the view widget for a specific item.
+
+        Parameters
+        ----------
+        i : int
+            The index of the classlist item displayed by this widget.
+
+        Returns
+        -------
+        QtWidgets.QWidget
+            The widget that displays the classlist item.
+
+        """
+        raise NotImplementedError
+
+    def create_editor(self, i: int) -> QtWidgets.QWidget:
+        """Create the edit widget for a specific item.
+
+        Parameters
+        ----------
+        i : int
+            The index of the classlist item displayed by this widget.
+
+        Returns
+        -------
+        QtWidgets.QWidget
+            The widget that allows the classlist item to be edited.
+
+        """
+        raise NotImplementedError
+
+
+class LayerStringListModel(QtCore.QStringListModel):
+    """A string list that supports drag and drop."""
+
+    def flags(self, index):
+        # we disable ItemIsDropEnabled to disable overwriting of items via drop
+        flags = super().flags(index)
+        if index.isValid():
+            flags &= ~QtCore.Qt.ItemFlag.ItemIsDropEnabled
+
+        return flags
+
+    def supportedDropActions(self):
+        return QtCore.Qt.DropAction.MoveAction
+
+
+class ContrastModelWidget(QtWidgets.QWidget):
+    """Widget for contrast models."""
+
+    def __init__(self, init_list: list[str] = None, parent=None):
+        super().__init__(parent)
+
+        self.model = LayerStringListModel(init_list, self)
+        self.list = QtWidgets.QListView(parent)
+        self.list.setModel(self.model)
+        self.list.setItemDelegateForColumn(0, ProjectFieldDelegate(parent.project_widget, "layers", self))
+        self.list.setDragEnabled(True)
+        self.list.setAcceptDrops(True)
+        self.list.setDropIndicatorShown(True)
+        self.list.setDragDropOverwriteMode(False)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.list)
+
+        self.setLayout(layout)
+
+
+class ContrastWidget(AbstractProjectListWidget):
+    """Widget for viewing and editing Contrasts."""
+
+    def compose_widget(self, i: int, data_widget: Callable[[str], QtWidgets.QWidget]) -> QtWidgets.QWidget:
+        """Create the base grid layouts for the widget.
+
+        Parameters
+        ----------
+        i : int
+            The row of the contrasts list to display in this widget.
+        data_widget_creator : Callable[[str], QtWidgets.QWidget]
+            A function which takes a field name and returns the data widget for that field.
+
+        Returns
+        -------
+        QtWidgets.QWidget
+            The resulting widget for the item.
+
+        """
+        top_grid = QtWidgets.QGridLayout()
+        top_grid.addWidget(QtWidgets.QLabel("Contrast Name:"), 0, 0)
+        top_grid.addWidget(data_widget("name"), 0, 1, 1, -1)
+
+        top_grid.addWidget(QtWidgets.QLabel("Background:"), 1, 0)
+        top_grid.addWidget(data_widget("background"), 1, 1, 1, 2)
+        top_grid.addWidget(QtWidgets.QLabel("Background Action:"), 1, 3)
+        top_grid.addWidget(data_widget("background_action"), 1, 4, 1, 2)
+
+        top_grid.addWidget(QtWidgets.QLabel("Resolution:"), 2, 0)
+        top_grid.addWidget(data_widget("resolution"), 2, 1)
+        top_grid.addWidget(QtWidgets.QLabel("Scalefactor:"), 2, 2)
+        top_grid.addWidget(data_widget("scalefactor"), 2, 3)
+        top_grid.addWidget(QtWidgets.QLabel("Data:"), 2, 4)
+        top_grid.addWidget(data_widget("data"), 2, 5)
+
+        top_grid.setVerticalSpacing(10)
+
+        settings_row = QtWidgets.QHBoxLayout()
+        settings_row.addWidget(QtWidgets.QLabel("Use resampling:"))
+        resampling_checkbox = QtWidgets.QCheckBox()
+        resampling_checkbox.setChecked(self.model.get_item(i).resample)
+        resampling_checkbox.checkStateChanged.connect(
+            lambda s: self.model.set_data(i, "resample", (s == QtCore.Qt.CheckState.Checked))
+        )
+        settings_row.addWidget(resampling_checkbox)
+        settings_row.addStretch()
+
+        model_grid = QtWidgets.QGridLayout()
+        model_grid.addWidget(QtWidgets.QLabel("Bulk in:"), 0, 0)
+        model_grid.addWidget(data_widget("bulk_in"), 0, 1)
+        model_grid.addWidget(QtWidgets.QLabel("Layers:"), 1, 0)
+        model_grid.addWidget(data_widget("model"), 1, 1)
+        model_grid.addWidget(QtWidgets.QLabel("Bulk out:"), 2, 0)
+        model_grid.addWidget(data_widget("bulk_out"), 2, 1)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addLayout(top_grid)
+        layout.addLayout(settings_row)
+        layout.addStretch()
+        layout.addLayout(model_grid)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        widget = QtWidgets.QWidget(self)
+        widget.setLayout(layout)
+
+        return widget
+
+    def create_view(self, i: int) -> QtWidgets.QWidget:
+        def data_box(field: str) -> QtWidgets.QWidget:
+            """Create a read only line edit box for display."""
+            current_data = getattr(self.model.get_item(i), field)
+            if field == "model":
+                widget = QtWidgets.QListWidget(parent=self)
+                widget.addItems(current_data)
+            else:
+                widget = QtWidgets.QLineEdit(current_data)
+                widget.setReadOnly(True)
+
+            return widget
+
+        return self.compose_widget(i, data_box)
+
+    def create_editor(self, i: int) -> QtWidgets.QWidget:
+        self.comboboxes = {}
+
+        def data_combobox(field: str) -> QtWidgets.QWidget:
+            current_data = getattr(self.model.get_item(i), field)
+            match field:
+                case "name":
+                    widget = QtWidgets.QLineEdit(current_data)
+                    widget.textChanged.connect(lambda text: self.model.set_data(i, "name", text))
+                    return widget
+                case "background_action":
+                    widget = QtWidgets.QComboBox()
+                    for action in BackgroundActions:
+                        widget.addItem(str(action), action)
+                    widget.setCurrentText(current_data)
+                    widget.currentTextChanged.connect(
+                        lambda: self.model.set_data(i, "background_action", widget.currentData())
+                    )
+                    return widget
+                case "model":
+                    widget = ContrastModelWidget(current_data, self)
+                    return widget
+                # all other cases are comboboxes with data from other widget tables
+                case "data" | "bulk_in" | "bulk_out":
+                    project_field_name = field
+                    pass
+                case _:
+                    project_field_name = field + "s"
+                    pass
+
+            project_field = self.project_widget.draft_project[project_field_name]
+            combobox = QtWidgets.QComboBox(self)
+            items = [""] + [item.name for item in project_field]
+            combobox.addItems(items)
+            combobox.setCurrentText(current_data)
+            combobox.currentTextChanged.connect(lambda: self.model.set_data(i, field, combobox.currentText()))
+            combobox.setSizePolicy(QtWidgets.QSizePolicy.Policy.MinimumExpanding, QtWidgets.QSizePolicy.Policy.Fixed)
+
+            return combobox
+
+        return self.compose_widget(i, data_combobox)

--- a/rascal2/widgets/project/lists.py
+++ b/rascal2/widgets/project/lists.py
@@ -268,11 +268,36 @@ class StandardLayerModelWidget(QtWidgets.QWidget):
         standard_layer_list.setDropIndicatorShown(True)
         standard_layer_list.setDragDropOverwriteMode(False)
 
+        add_button = QtWidgets.QPushButton("+")
+        add_button.pressed.connect(self.append_item)
+        delete_button = QtWidgets.QPushButton(icon=QtGui.QIcon(path_for("delete.png")))
+        delete_button.pressed.connect(self.delete_item)
+
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.addWidget(add_button)
+        buttons.addWidget(delete_button)
+
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(standard_layer_list)
+        layout.addLayout(buttons)
 
         self.setLayout(layout)
 
+    def get_data(self):
+        """Get the data from the model."""
+        return self.model.stringList()
+
+    def append_item(self):
+        """Append an item to the model if the model exists."""
+        if self.model is not None:
+            self.model.insertRows(self.model.rowCount(), 1)
+            self.model.setData(self.model.index(self.model.rowCount() - 1, 0), "Choose Layer...")
+
+    def delete_item(self):
+        """Delete the currently selected item."""
+        if self.model is not None:
+            selection_model = self.list.selectionModel()
+            self.model.removeRows(selection_model.currentIndex().row(), 1)
 
 class ContrastWidget(AbstractProjectListWidget):
     """Widget for viewing and editing Contrasts."""

--- a/rascal2/widgets/project/models.py
+++ b/rascal2/widgets/project/models.py
@@ -15,7 +15,7 @@ from rascal2.config import path_for
 from rascal2.dialogs.custom_file_editor import edit_file, edit_file_matlab
 
 
-class ClassListModel(QtCore.QAbstractTableModel):
+class ClassListTableModel(QtCore.QAbstractTableModel):
     """Table model for a project ClassList field.
 
     Parameters
@@ -45,7 +45,7 @@ class ClassListModel(QtCore.QAbstractTableModel):
         self.classlist = classlist
         self.item_type = classlist._class_handle
         if not issubclass(self.item_type, pydantic.BaseModel):
-            raise NotImplementedError("ClassListModel only works for classlists of Pydantic models!")
+            raise NotImplementedError("ClassListTableModel only works for classlists of Pydantic models!")
         self.headers = list(self.item_type.model_fields)
 
     def rowCount(self, parent=None) -> int:
@@ -153,7 +153,7 @@ class ProjectFieldWidget(QtWidgets.QWidget):
 
     """
 
-    classlist_model = ClassListModel
+    classlist_model = ClassListTableModel
 
     # the model can change and disconnect, so we re-connect it
     # to a signal here on each change
@@ -249,7 +249,7 @@ class ProjectFieldWidget(QtWidgets.QWidget):
         presenter.edit_project({self.field: self.model.classlist})
 
 
-class ParametersModel(ClassListModel):
+class ParametersModel(ClassListTableModel):
     """Classlist model for Parameters."""
 
     def __init__(self, classlist: RATapi.ClassList, parent: QtWidgets.QWidget):
@@ -326,7 +326,7 @@ class ParameterFieldWidget(ProjectFieldWidget):
                 self.table.setIndexWidget(self.model.index(i, 0), None)
 
 
-class LayersModel(ClassListModel):
+class LayersModel(ClassListTableModel):
     """Classlist model for Layers."""
 
     def __init__(self, classlist: RATapi.ClassList, parent: QtWidgets.QWidget):
@@ -394,16 +394,6 @@ class LayersModel(ClassListModel):
             self.endResetModel()
 
 
-class ContrastsModel(ClassListModel):
-    """Classlist model for Contrasts."""
-
-    def flags(self, index):
-        flags = super().flags(index)
-        if self.edit_mode:
-            flags |= QtCore.Qt.ItemFlag.ItemIsEditable
-        return flags
-
-
 class LayerFieldWidget(ProjectFieldWidget):
     """Project field widget for Layer objects."""
 
@@ -439,7 +429,7 @@ class LayerFieldWidget(ProjectFieldWidget):
             self.edit()
 
 
-class DomainsModel(ClassListModel):
+class DomainsModel(ClassListTableModel):
     """Classlist model for domain contrasts."""
 
     def flags(self, index):
@@ -472,7 +462,7 @@ class DomainContrastWidget(ProjectFieldWidget):
         self.table.setItemDelegateForColumn(2, delegates.MultiSelectLayerDelegate(self.project_widget, self.table))
 
 
-class CustomFileModel(ClassListModel):
+class CustomFileModel(ClassListTableModel):
     """Classlist model for custom files."""
 
     def __init__(self, classlist: RATapi.ClassList, parent: QtWidgets.QWidget):

--- a/rascal2/widgets/project/project.py
+++ b/rascal2/widgets/project/project.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 
 import RATapi
+from pydantic import ValidationError
 from PyQt6 import QtCore, QtGui, QtWidgets
 from RATapi.utils.enums import Calculations, Geometries, LayerModels
 
@@ -344,40 +345,21 @@ class ProjectWidget(QtWidgets.QWidget):
         except ValueError as err:
             self.parent.terminal_widget.write_error(f"Could not save draft project:\n  {err}")
         else:
-            self.parent.presenter.edit_project(self.draft_project)
-            self.update_project_view()
-            self.parent.controls_widget.run_button.setEnabled(True)
-            self.show_project_view()
+            # catch errors from Pydantic as fallback rather than crashing
+            try:
+                self.parent.presenter.edit_project(self.draft_project)
+            except ValidationError as err:
+                self.parent.terminal_widget.write_error(f"Could not save draft project:\n  {err}")
+            else:
+                self.update_project_view()
+                self.parent.controls_widget.run_button.setEnabled(True)
+                self.show_project_view()
 
     def validate_draft_project(self):
         """Check that the draft project is valid."""
         errors = []
-        if self.draft_project["model"] == LayerModels.StandardLayers and self.draft_project["layers"]:
-            layer_attrs = list(self.draft_project["layers"][0].model_fields)
-            layer_attrs.remove("name")
-            layer_attrs.remove("hydrate_with")
-            # ensure all layer parameters have been filled in, and all names are layers that exist
-            valid_params = [p.name for p in self.draft_project["parameters"]]
-            for i, layer in enumerate(self.draft_project["layers"]):
-                missing_params = []
-                invalid_params = []
-                for attr in layer_attrs:
-                    param = getattr(layer, attr)
-                    if param == "":
-                        missing_params.append(attr)
-                    elif param not in valid_params:
-                        invalid_params.append((attr, param))
-
-                if missing_params:
-                    noun = "a parameter" if len(missing_params) == 1 else "parameters"
-                    msg = f"Layer '{layer.name}' (row {i + 1}) is missing {noun}: {', '.join(missing_params)}"
-                    errors.append(msg)
-                if invalid_params:
-                    noun = "an invalid value" if len(invalid_params) == 1 else "invalid values"
-                    msg = f"Layer '{layer.name}' (row {i + 1}) has {noun}: {{0}}".format(
-                        ",\n  ".join(f'"{v}" for parameter {p}' for p, v in invalid_params)
-                    )
-                    errors.append(msg)
+        errors.extend(self.edit_tabs["Layers"].tables["layers"].validate())
+        errors.extend(self.edit_tabs["Contrasts"].tables["contrasts"].validate())
 
         if errors:
             raise ValueError("\n  ".join(errors))

--- a/rascal2/widgets/project/project.py
+++ b/rascal2/widgets/project/project.py
@@ -242,6 +242,10 @@ class ProjectWidget(QtWidgets.QWidget):
         # because we don't want validation errors going off while editing the model is in-progress
         self.draft_project: dict = create_draft_project(self.parent_model.project)
 
+        for tab in self.tabs:
+            self.view_tabs[tab].update_model(self.draft_project)
+            self.edit_tabs[tab].update_model(self.draft_project)
+
         self.absorption_checkbox.setChecked(self.parent_model.project.absorption)
         self.calculation_type.setText(self.parent_model.project.calculation)
         self.model_type.setText(self.parent_model.project.model)
@@ -251,10 +255,6 @@ class ProjectWidget(QtWidgets.QWidget):
         self.calculation_combobox.setCurrentText(self.parent_model.project.calculation)
         self.model_combobox.setCurrentText(self.parent_model.project.model)
         self.geometry_combobox.setCurrentText(self.parent_model.project.geometry)
-
-        for tab in self.tabs:
-            self.view_tabs[tab].update_model(self.draft_project)
-            self.edit_tabs[tab].update_model(self.draft_project)
 
         self.handle_tabs()
         self.handle_controls_update()
@@ -460,11 +460,6 @@ class ProjectTabWidget(QtWidgets.QWidget):
             table.update_model(classlist)
             if self.edit_mode:
                 table.edit()
-            if "layers" in self.tables:
-                self.tables["layers"].set_absorption(new_model["absorption"])
-            if "contrasts" in self.tables:
-                self.tables["contrasts"].set_domains(new_model["calculation"] == Calculations.Domains)
-
 
     def handle_controls_update(self, controls):
         """Reflect changes to the Controls object."""

--- a/rascal2/widgets/project/project.py
+++ b/rascal2/widgets/project/project.py
@@ -203,11 +203,15 @@ class ProjectWidget(QtWidgets.QWidget):
         self.edit_absorption_checkbox.checkStateChanged.connect(
             lambda s: self.update_draft_project({"absorption": s == QtCore.Qt.CheckState.Checked})
         )
-        # when calculation type changed, update the draft project and show/hide the domains tab
+        # when calculation type changed, update the draft project, show/hide the domains tab,
+        # and change contrasts to have ratio
         self.calculation_combobox.currentTextChanged.connect(lambda s: self.update_draft_project({"calculation": s}))
         self.calculation_combobox.currentTextChanged.connect(lambda: self.handle_tabs())
+        self.calculation_combobox.currentTextChanged.connect(
+            lambda s: self.edit_tabs["Contrasts"].tables["contrasts"].set_domains(s == Calculations.Domains)
+        )
 
-        # when model type changed, hide/show layers tab and
+        # when model type changed, hide/show layers tab and change model field in contrasts
         self.model_combobox.currentTextChanged.connect(lambda: self.handle_tabs())
         self.model_combobox.currentTextChanged.connect(lambda s: self.handle_model_update(s))
 
@@ -222,7 +226,7 @@ class ProjectWidget(QtWidgets.QWidget):
             lambda s: self.edit_tabs["Layers"].tables["layers"].set_absorption(s == QtCore.Qt.CheckState.Checked)
         )
 
-        for tab in ["Experimental Parameters", "Layers", "Backgrounds"]:
+        for tab in ["Experimental Parameters", "Layers", "Backgrounds", "Domains"]:
             for table in self.edit_tabs[tab].tables.values():
                 table.edited.connect(lambda: self.edit_tabs["Contrasts"].tables["contrasts"].update_item_view())
 
@@ -458,6 +462,9 @@ class ProjectTabWidget(QtWidgets.QWidget):
                 table.edit()
             if "layers" in self.tables:
                 self.tables["layers"].set_absorption(new_model["absorption"])
+            if "contrasts" in self.tables:
+                self.tables["contrasts"].set_domains(new_model["calculation"] == Calculations.Domains)
+
 
     def handle_controls_update(self, controls):
         """Reflect changes to the Controls object."""

--- a/rascal2/widgets/project/project.py
+++ b/rascal2/widgets/project/project.py
@@ -7,6 +7,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from RATapi.utils.enums import Calculations, Geometries, LayerModels
 
 from rascal2.config import path_for
+from rascal2.widgets.project.lists import ContrastWidget
 from rascal2.widgets.project.models import (
     CustomFileWidget,
     DomainContrastWidget,
@@ -45,7 +46,7 @@ class ProjectWidget(QtWidgets.QWidget):
             "Backgrounds": [],
             "Domains": ["domain_ratios", "domain_contrasts"],
             "Custom Files": ["custom_files"],
-            "Contrasts": [],
+            "Contrasts": ["contrasts"],
         }
 
         self.view_tabs = {}
@@ -214,6 +215,10 @@ class ProjectWidget(QtWidgets.QWidget):
         self.edit_absorption_checkbox.checkStateChanged.connect(
             lambda s: self.edit_tabs["Layers"].tables["layers"].set_absorption(s == QtCore.Qt.CheckState.Checked)
         )
+
+        for tab in ["Experimental Parameters", "Layers", "Backgrounds"]:
+            for table in self.edit_tabs[tab].tables.values():
+                table.edited.connect(lambda: self.edit_tabs["Contrasts"].tables["contrasts"].update_item_view())
 
         main_layout.addWidget(self.edit_project_tab)
 
@@ -386,6 +391,8 @@ class ProjectTabWidget(QtWidgets.QWidget):
                 self.tables[field] = DomainContrastWidget(field, self)
             elif field == "custom_files":
                 self.tables[field] = CustomFileWidget(field, self)
+            elif field == "contrasts":
+                self.tables[field] = ContrastWidget(field, self)
             else:
                 self.tables[field] = ProjectFieldWidget(field, self)
             layout.addWidget(self.tables[field])

--- a/rascal2/widgets/project/project.py
+++ b/rascal2/widgets/project/project.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import RATapi
 from pydantic import ValidationError
 from PyQt6 import QtCore, QtGui, QtWidgets
+from RATapi.utils.custom_errors import custom_pydantic_validation_error
 from RATapi.utils.enums import Calculations, Geometries, LayerModels
 
 from rascal2.config import path_for
@@ -349,7 +350,9 @@ class ProjectWidget(QtWidgets.QWidget):
             try:
                 self.parent.presenter.edit_project(self.draft_project)
             except ValidationError as err:
-                self.parent.terminal_widget.write_error(f"Could not save draft project:\n  {err}")
+                custom_error_list = custom_pydantic_validation_error(err.errors(include_url=False))
+                custom_errors = ValidationError.from_exception_data(err.title, custom_error_list, hide_input=True)
+                self.parent.terminal_widget.write_error(f"Could not save draft project:\n  {custom_errors}")
             else:
                 self.update_project_view()
                 self.parent.controls_widget.run_button.setEnabled(True)

--- a/tests/widgets/project/test_lists.py
+++ b/tests/widgets/project/test_lists.py
@@ -1,0 +1,251 @@
+"""Tests for list tab/model views."""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt6 import QtWidgets
+from RATapi import ClassList
+
+from rascal2.widgets.project.lists import AbstractProjectListWidget, ClassListItemModel, StandardLayerModelWidget
+
+
+class MockMainWindow(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.parent = MagicMock()
+        self.project_widget = MagicMock()
+
+
+parent = MockMainWindow()
+
+
+@dataclass
+class MockDataClass:
+    name: str = "New Item"
+    val: int = 0
+
+
+class MockProjectListWidget(AbstractProjectListWidget):
+    """A mock implementation of the project list widget."""
+
+    def create_view(self, i):
+        return QtWidgets.QLabel(self.model.classlist[i].name)
+
+    def create_editor(self, i):
+        return QtWidgets.QLabel(str(self.model.classlist[i].val))
+
+
+@pytest.fixture
+def mock_item_model():
+    init_classlist = ClassList(
+        [
+            MockDataClass("a", 1),
+            MockDataClass("b", 2),
+            MockDataClass("c", 3),
+        ]
+    )
+    return ClassListItemModel(init_classlist, parent)
+
+
+@pytest.fixture
+def mock_project_widget():
+    def create_project_widget(edit_mode: bool = False):
+        widget = MockProjectListWidget("mocks", parent)
+        widget.update_model(
+            ClassList(
+                [
+                    MockDataClass("a", 1),
+                    MockDataClass("b", 2),
+                    MockDataClass("c", 3),
+                ]
+            )
+        )
+        if edit_mode:
+            widget.edit()
+
+        return widget
+
+    return create_project_widget
+
+
+def test_classlist_item_model_init(mock_item_model):
+    """Test that the ClassListItemModel has the expected data on creation."""
+    init_classlist = ClassList(
+        [
+            MockDataClass("a", 1),
+            MockDataClass("b", 2),
+            MockDataClass("c", 3),
+        ]
+    )
+
+    assert mock_item_model.classlist == init_classlist
+    assert mock_item_model.item_type == MockDataClass
+    assert not mock_item_model.edit_mode
+
+    assert mock_item_model.rowCount() == 3
+    for i, item in enumerate(init_classlist):
+        assert mock_item_model.data(mock_item_model.index(i, 0)) == item.name
+        assert mock_item_model.get_item(i) == item
+
+
+def test_classlist_item_model_edit(mock_item_model):
+    """Test that setting data in the ClassListItemModel works as expected."""
+    mock_item_model.set_data(1, "val", 5)
+    assert mock_item_model.get_item(1) == MockDataClass("b", 5)
+
+    mock_item_model.set_data(2, "name", "d")
+    assert mock_item_model.get_item(2) == MockDataClass("d", 3)
+
+
+def test_classlist_item_model_append(mock_item_model):
+    """Test that appending an item to the ClassListItemModel works as expected."""
+    mock_item_model.append_item()
+
+    assert mock_item_model.rowCount() == 4
+    assert mock_item_model.get_item(-1) == MockDataClass()
+
+
+def test_classlist_item_model_delete(mock_item_model):
+    """Test that deleting items from the ClassListItemModel works as expected."""
+    mock_item_model.delete_item(1)
+    assert mock_item_model.rowCount() == 2
+    assert mock_item_model.get_item(0) == MockDataClass("a", 1)
+    assert mock_item_model.get_item(1) == MockDataClass("c", 3)
+
+
+def test_project_list_widget_init():
+    """Test the initial state of the abstract project list widget."""
+    widget = AbstractProjectListWidget("nothing", parent)
+
+    assert not widget.edit_mode
+    assert not widget.add_button.isVisibleTo(widget)
+    assert not widget.delete_button.isVisibleTo(widget)
+
+
+def test_project_list_widget_edit():
+    """Test the correct changes are made when edit mode is activated on the project list widget."""
+    widget = AbstractProjectListWidget("nothing", parent)
+    widget.edit()
+
+    assert widget.edit_mode
+    assert widget.add_button.isVisibleTo(widget)
+    assert widget.delete_button.isVisibleTo(widget)
+
+
+def test_project_list_widget_empty_model():
+    """Test that a message is shown if an empty model is given to the widget."""
+    widget = AbstractProjectListWidget("nothing", parent)
+    empty_classlist = ClassList()
+    empty_classlist._class_handle = None
+    widget.update_model(empty_classlist)
+
+    assert isinstance(widget.view_stack, QtWidgets.QLabel)
+    assert widget.view_stack.text() == "No items are currently defined! Edit the project to add a item."
+
+
+@pytest.mark.parametrize("edit_mode, expected_labels", ([False, ["a", "b", "c"]], [True, ["1", "2", "3"]]))
+def test_project_list_widget_build(mock_project_widget, edit_mode, expected_labels):
+    """Test that the project list widget builds correctly when given a model."""
+
+    widget = mock_project_widget(edit_mode)
+
+    assert widget.view_stack.count() == 3
+
+    for i, val in enumerate(expected_labels):
+        widget.view_stack.setCurrentIndex(i)
+
+        assert widget.view_stack.currentWidget().text() == val
+
+
+@pytest.mark.parametrize("edit_mode, expected_labels", ([False, ["a", "b", "c"]], [True, ["1", "2", "3"]]))
+def test_project_list_widget_choose(mock_project_widget, edit_mode, expected_labels):
+    """Test that the current widget changes when the item is selected."""
+
+    widget = mock_project_widget(edit_mode)
+
+    for i, label in enumerate(expected_labels):
+        sel_mod = widget.list.selectionModel()
+        sel_mod.setCurrentIndex(widget.model.index(i, 0), sel_mod.SelectionFlag.ClearAndSelect)
+        assert widget.view_stack.currentWidget().text() == label
+
+
+@pytest.mark.parametrize("edit_mode, expected_label", ([False, "New Item"], [True, "0"]))
+def test_project_list_widget_append(mock_project_widget, edit_mode, expected_label):
+    """Test that items are correctly appended to a project list widget."""
+
+    widget = mock_project_widget(edit_mode)
+
+    widget.append_item()
+
+    assert widget.view_stack.count() == 4
+
+    widget.view_stack.setCurrentIndex(3)
+    assert widget.view_stack.currentWidget().text() == expected_label
+
+
+def test_project_list_widget_delete(mock_project_widget):
+    """Test that items are correctly deleted from a project list widget."""
+
+    widget = mock_project_widget()
+
+    sel_mod = widget.list.selectionModel()
+    sel_mod.setCurrentIndex(widget.model.index(1, 0), sel_mod.SelectionFlag.ClearAndSelect)
+
+    widget.delete_item()
+
+    assert widget.view_stack.count() == 2
+
+    for i, expected_label in enumerate(["a", "c"]):
+        widget.view_stack.setCurrentIndex(i)
+        assert widget.view_stack.currentWidget().text() == expected_label
+
+
+def test_standard_layer_widget_init():
+    """Test that the StandardLayerModelWidget initialises as expected."""
+
+    widget = StandardLayerModelWidget(["a", "b", "c"], parent)
+
+    assert widget.layer_list.model().stringList() == ["a", "b", "c"]
+
+
+@pytest.mark.parametrize("selected_index", [0, 1, 2])
+def test_standard_layer_widget_append(selected_index):
+    """Test that the StandardLayerModelWidget appends items correctly."""
+    init_list = ["a", "b", "c"]
+    widget = StandardLayerModelWidget(init_list, parent)
+
+    sel_mod = widget.layer_list.selectionModel()
+    sel_mod.setCurrentIndex(widget.model.index(selected_index, 0), sel_mod.SelectionFlag.ClearAndSelect)
+    widget.append_item()
+
+    assert widget.model.stringList() == init_list[: selected_index + 1] + [""] + init_list[selected_index + 1 :]
+    assert widget.layer_list.state() == widget.layer_list.State.EditingState
+
+
+@pytest.mark.parametrize("selected_index", [0, 1, 2])
+def test_standard_layer_widget_delete(selected_index):
+    """Test that the StandardLayerModelWidget deletes items correctly."""
+    init_list = ["a", "b", "c"]
+    widget = StandardLayerModelWidget(init_list, parent)
+
+    sel_mod = widget.layer_list.selectionModel()
+    sel_mod.setCurrentIndex(widget.model.index(selected_index, 0), sel_mod.SelectionFlag.ClearAndSelect)
+    widget.delete_item()
+
+    assert widget.model.stringList() == init_list[:selected_index] + init_list[selected_index + 1 :]
+
+
+@pytest.mark.parametrize("selected_index", [0, 1, 2])
+@pytest.mark.parametrize("delta", [1, -1, 2, -2, 5])
+def test_standard_layer_widget_move(selected_index, delta):
+    """Test that the StandardLayerModelWidget moves items correctly."""
+    init_list = ["a", "b", "c"]
+    widget = StandardLayerModelWidget(init_list, parent)
+
+    sel_mod = widget.layer_list.selectionModel()
+    sel_mod.setCurrentIndex(widget.model.index(selected_index, 0), sel_mod.SelectionFlag.ClearAndSelect)
+    widget.move_item(delta)
+
+    init_list.insert(max(selected_index + delta, 0), init_list.pop(selected_index))
+    assert widget.model.stringList() == init_list

--- a/tests/widgets/project/test_lists.py
+++ b/tests/widgets/project/test_lists.py
@@ -14,6 +14,7 @@ class MockMainWindow(QtWidgets.QMainWindow):
     def __init__(self):
         super().__init__()
         self.parent = MagicMock()
+        self.model = MagicMock()
         self.project_widget = MagicMock()
 
 

--- a/tests/widgets/project/test_models.py
+++ b/tests/widgets/project/test_models.py
@@ -11,7 +11,7 @@ from RATapi.utils.enums import Languages
 import rascal2.widgets.delegates as delegates
 import rascal2.widgets.inputs as inputs
 from rascal2.widgets.project.models import (
-    ClassListModel,
+    ClassListTableModel,
     CustomFileModel,
     CustomFileWidget,
     DomainContrastWidget,
@@ -52,8 +52,8 @@ def classlist():
 
 @pytest.fixture
 def table_model(classlist):
-    """A test ClassListModel."""
-    return ClassListModel(classlist, parent)
+    """A test ClassListTableModel."""
+    return ClassListTableModel(classlist, parent)
 
 
 @pytest.fixture
@@ -93,7 +93,7 @@ parent = MockMainWindow()
 
 
 def test_model_init(table_model, classlist):
-    """Test that initialisation works correctly for ClassListModels."""
+    """Test that initialisation works correctly for ClassListTableModels."""
     model = table_model
 
     assert model.classlist == classlist

--- a/tests/widgets/project/test_models.py
+++ b/tests/widgets/project/test_models.py
@@ -363,12 +363,12 @@ def test_layer_widget_delegates(init_class):
 
     expected_delegates = {
         "name": delegates.ValidatedInputDelegate,
-        "thickness": delegates.ParametersDelegate,
-        "SLD": delegates.ParametersDelegate,
-        "SLD_real": delegates.ParametersDelegate,
-        "SLD_imaginary": delegates.ParametersDelegate,
-        "roughness": delegates.ParametersDelegate,
-        "hydration": delegates.ParametersDelegate,
+        "thickness": delegates.ProjectFieldDelegate,
+        "SLD": delegates.ProjectFieldDelegate,
+        "SLD_real": delegates.ProjectFieldDelegate,
+        "SLD_imaginary": delegates.ProjectFieldDelegate,
+        "roughness": delegates.ProjectFieldDelegate,
+        "hydration": delegates.ProjectFieldDelegate,
         "hydrate_with": delegates.ValidatedInputDelegate,
     }
 

--- a/tests/widgets/project/test_project.py
+++ b/tests/widgets/project/test_project.py
@@ -8,7 +8,7 @@ from PyQt6 import QtCore, QtWidgets
 from RATapi.utils.enums import Calculations, Geometries, LayerModels
 
 from rascal2.widgets.project.models import (
-    ClassListModel,
+    ClassListTableModel,
     ParameterFieldWidget,
     ParametersModel,
     ProjectFieldWidget,
@@ -57,8 +57,8 @@ def classlist():
 
 @pytest.fixture
 def table_model(classlist):
-    """A test ClassListModel."""
-    return ClassListModel(classlist, parent)
+    """A test ClassListTableModel."""
+    return ClassListTableModel(classlist, parent)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR uses the same format as python-RAT for pydantic error messages, removing Stephen's hated urls. As far as I'm aware, this is the only place in the GUI where pydantic errors are expected to be outputted, please advise if there's anywhere else I need to look.