### PR TITLE
Adds live recalculate option

### DIFF
--- a/rascal2/core/settings.py
+++ b/rascal2/core/settings.py
@@ -97,7 +97,7 @@ class Settings(BaseModel, validate_assignment=True, arbitrary_types_allowed=True
     Notes
     -----
     For each system setting, the model field `title` contains the setting group,
-    and the model field `description` gives an English name for the setting.
+    and the model field `description` gives a description for the setting.
     The model fields for a setting can be accessed via Settings.model_fields[setting].
 
     """
@@ -106,6 +106,9 @@ class Settings(BaseModel, validate_assignment=True, arbitrary_types_allowed=True
     # The global settings are read and written via this object using `set_global_settings`.
     style: Styles = Field(default=Styles.Light, title=SettingsGroups.General, description="Style")
     editor_fontsize: int = Field(default=12, title=SettingsGroups.General, description="Editor Font Size", gt=0)
+    live_recalculate: bool = Field(
+        default=True, title=SettingsGroups.General, description="Auto-run simulation when parameter values change."
+    )
 
     log_path: str = Field(default="logs/rascal.log", title=SettingsGroups.Logging, description="Path to Log File")
     log_level: LogLevels = Field(default=LogLevels.Info, title=SettingsGroups.Logging, description="Minimum Log Level")

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -136,12 +136,26 @@ class MainWindowPresenter:
         """Sends an interrupt signal to the RAT runner."""
         self.runner.interrupt()
 
-    def run(self):
-        """Run RAT."""
+    def run(self, procedure: RAT.utils.enums.Procedures = None):
+        """Run RAT.
+
+        Parameters
+        ----------
+        procedure : Procedures, optional
+            What procedure to run with. If None, will use the procedure
+            from the model controls.
+
+        """
         # reset terminal
         self.view.terminal_widget.progress_bar.setVisible(False)
         if self.view.settings.clear_terminal:
             self.view.terminal_widget.clear()
+
+        # saving the old procedure, changing it, and setting it back at the end
+        # is cheaper than copying controls if procedure is not None
+        old_procedure = self.model.controls.procedure
+        if procedure is not None:
+            self.model.controls.procedure = procedure
 
         rat_inputs = RAT.inputs.make_input(self.model.project, self.model.controls)
         display_on = self.model.controls.display != RAT.utils.enums.Display.Off
@@ -151,6 +165,8 @@ class MainWindowPresenter:
         self.runner.stopped.connect(self.handle_interrupt)
         self.runner.event_received.connect(self.handle_event)
         self.runner.start()
+
+        self.model.controls.procedure = old_procedure
 
     def handle_results(self):
         """Handle a RAT run being finished."""

--- a/rascal2/widgets/project/models.py
+++ b/rascal2/widgets/project/models.py
@@ -85,7 +85,9 @@ class ClassListModel(QtCore.QAbstractTableModel):
                 except pydantic.ValidationError:
                     return False
                 if not self.edit_mode:
-                    self.parent.update_project()
+                    # recalculate plots if value was changed
+                    recalculate = self.index_header(index) == "value"
+                    self.parent.update_project(recalculate)
                 self.dataChanged.emit(index, index)
                 return True
         return False
@@ -237,10 +239,18 @@ class ProjectFieldWidget(QtWidgets.QWidget):
 
         return button
 
-    def update_project(self):
-        """Update the field in the parent Project."""
+    def update_project(self, recalculate: bool):
+        """Update the field in the parent Project.
+
+        Parameters
+        ----------
+        recalculate : bool
+            Whether to recalculate the plots when the project updates.
+        """
         presenter = self.parent.parent.parent.presenter
         presenter.edit_project({self.field: self.model.classlist})
+        if recalculate and presenter.view.settings.live_recalculate:
+            presenter.run("calculate")
 
 
 class ParametersModel(ClassListModel):


### PR DESCRIPTION
Fixes #70 - automatically runs a calculation when a user changes the value of a parameter (of any type). This can be switched off via a new `live_recalculate` setting (e.g. if a project is complex and even a normal calculation might take a long time)