### PR TITLE
Fixes runner and tests, and adds new test for runner

### DIFF
--- a/rascal2/core/commands.py
+++ b/rascal2/core/commands.py
@@ -127,9 +127,7 @@ class SaveCalculationOutputs(QtGui.QUndoCommand):
         self.results = results
         self.log = log
         self.problem = self.get_parameter_values(problem)
-        checks = RATapi.rat_core.Checks()
-        checks.qzshifts = []
-        self.old_problem = self.get_parameter_values(RATapi.inputs.make_problem(self.presenter.model.project, checks))
+        self.old_problem = self.get_parameter_values(RATapi.inputs.make_problem(self.presenter.model.project))
         self.old_results = copy.deepcopy(self.presenter.model.results)
         self.old_log = self.presenter.model.result_log
         self.setText("Save calculation results")

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -75,7 +75,7 @@ def run(queue, rat_inputs: tuple, procedure: str, display: bool):
         Whether to display events.
 
     """
-    problem_definition, limits, priors, cpp_controls = rat_inputs
+    problem_definition, cpp_controls = rat_inputs
 
     if display:
         RAT.events.register(RAT.events.EventTypes.Message, queue.put)
@@ -84,9 +84,7 @@ def run(queue, rat_inputs: tuple, procedure: str, display: bool):
         queue.put(LogData(INFO, "Starting RAT"))
 
     try:
-        problem_definition, output_results, bayes_results = RAT.rat_core.RATMain(
-            problem_definition, limits, cpp_controls, priors
-        )
+        problem_definition, output_results, bayes_results = RAT.rat_core.RATMain(problem_definition, cpp_controls)
         results = RAT.outputs.make_results(procedure, output_results, bayes_results)
     except Exception as err:
         queue.put(err)

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -1,5 +1,7 @@
 """Tests for the RATRunner class."""
 
+import contextlib
+import os
 from queue import Queue  # we need a non-multiprocessing queue because mocks cannot be serialised
 from unittest.mock import MagicMock, patch
 
@@ -150,7 +152,10 @@ def test_run_examples(example):
     if example == "convert_rascal":
         return
 
-    project, _ = getattr(RAT.examples, example)()
+    # suppress RAT printing
+    with open(os.devnull, "w", encoding="utf-8") as stdout, contextlib.redirect_stdout(stdout):
+        project, _ = getattr(RAT.examples, example)()
+
     rat_inputs = RAT.inputs.make_input(project, RAT.Controls())
 
     queue = Queue()

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -99,7 +99,7 @@ def test_empty_queue(mock_process):
 def test_run(display):
     """Test that a run puts the correct items in the queue."""
     queue = Queue()
-    run(queue, [0, 1, 2, 3], "", display)
+    run(queue, [0, 1], "", display)
     expected_display = [
         LogData(20, "Starting RAT"),
         0.2,
@@ -132,7 +132,7 @@ def test_run_error():
 
     queue = Queue()
     with patch("RATapi.rat_core.RATMain", new=erroring_ratmain):
-        run(queue, [0, 1, 2, 3], "", True)
+        run(queue, [0, 1], "", True)
 
     queue.put(None)
     queue_contents = list(iter(queue.get, None))
@@ -141,3 +141,22 @@ def test_run_error():
     error = queue_contents[1]
     assert isinstance(error, ValueError)
     assert str(error) == "RAT Main Error!"
+
+
+@pytest.mark.parametrize("example", RAT.examples.__all__)
+def test_run_examples(example):
+    """Test that the run function runs without an error on the RATapi example projects."""
+    # skip convert rascal example
+    if example == "convert_rascal":
+        return
+
+    project, _ = getattr(RAT.examples, example)()
+    rat_inputs = RAT.inputs.make_input(project, RAT.Controls())
+
+    queue = Queue()
+    run(queue, rat_inputs, "calculate", False)
+
+    output = queue.get()
+
+    assert isinstance(output[0], RAT.rat_core.ProblemDefinition)
+    assert isinstance(output[1], RAT.outputs.Results)


### PR DESCRIPTION
It turns out the runner was broken by the new RATapi version, and no test actually catches if the runner works. This PR fixes the runner and also adds a test that runs the RAT runner on a set of examples.