### PR TITLE
Removes spawn as default process start method

### DIFF
--- a/packaging/build_exe.py
+++ b/packaging/build_exe.py
@@ -123,10 +123,6 @@ def build_exe():
             ver_file.write(f'!define VERSION "{RASCAL2_VERSION}"')
 
     arch_path = dist_path / "bin" / "_internal" / "matlab" / "engine" / "_arch.txt"
-    warnings.warn(
-        f"MATLAB engine arch file ({arch_path}) was not found. Ignore this if you don't plan to use MATLAB",
-        stacklevel=2,
-    )
     if arch_path.exists():
         open(dist_path / "bin" / "_internal" / "matlab" / "engine" / "_arch.txt", "w").close()
     else:

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -90,6 +90,9 @@ def run(queue, rat_inputs: tuple, procedure: str, display: bool, engine_ready, e
 
     engine_future = None
     if any([file["language"] == "matlab" for file in problem_definition.customFiles.files]):
+        if not engine_output:
+            queue.put(LogData(INFO, "Attempting to start Matlab..."))
+
         result = get_matlab_engine(engine_ready, engine_output)
         if isinstance(result, Exception):
             queue.put(result)

--- a/rascal2/main.py
+++ b/rascal2/main.py
@@ -44,7 +44,7 @@ def main():
     sys.excepthook = log_uncaught_exceptions
     MATLAB_HELPER.async_start()
     exit_code = ui_execute()
-    MATLAB_HELPER.shutdown()
+    MATLAB_HELPER.close_event.set()
     sys.exit(exit_code)
 
 


### PR DESCRIPTION
`spawn` start method leads to a memory leak in the pyInstaller build for Linux