### PR TITLE
Add installer build script for MacOS

### DIFF
--- a/.github/workflows/build_installer.yaml
+++ b/.github/workflows/build_installer.yaml
@@ -13,7 +13,7 @@ jobs:
   windows-installer:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: conda-incubator/setup-miniconda@v3
         with:
             activate-environment: rascal2
@@ -29,6 +29,7 @@ jobs:
           conda init powershell
           conda activate rascal2
           conda install -c nsis nsis=3.* accesscontrol
+          pip install matlabengine==9.14.*
           python packaging/build_exe.py
           makensis packaging/windows/build_installer.nsi
       - name: Upload installer
@@ -40,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
@@ -64,10 +65,51 @@ jobs:
         with:
           name: linux installer
           path: packaging/linux/*.run
+  macos-installer:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ macos-15-intel, macos-14 ]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+            activate-environment: rascal2
+            environment-file: environment.yaml
+            auto-activate-base: false
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: R2023b
+      - name: Make installer
+        shell: bash -el {0}
+        run: |
+          conda init bash
+          conda activate rascal2
+          if [ ${{ matrix.platform }} == "macos-14" ]; then
+            ARCH="arm64"
+            export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/bin/maca64
+            python -m pip install --no-build-isolation /Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/extern/engines/python    
+          else
+            ARCH="x64"
+            export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/runner/hostedtoolcache/MATLAB/2023.2.999/x64/MATLAB.app/bin/maci64
+            python -m pip install --no-build-isolation /Users/runner/hostedtoolcache/MATLAB/2023.2.999/x64/MATLAB.app/extern/engines/python
+          fi
+          python packaging/build_exe.py
+          chmod 777 packaging/bundle/rascal.app/Contents/Resources/matlab/engine/_arch.txt
+          cd packaging/macos/
+          chmod 777 make.sh
+          ./make.sh $GITHUB_REF_NAME $ARCH
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: macOS installer-${{ strategy.job-index }}
+          path: packaging/macos/rascal2-*.pkg
   deploy-nightly:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [windows-installer, linux-installer]
+    needs: [windows-installer, linux-installer, macos-installer]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -42,4 +42,3 @@ jobs:
       - name: Install and run tests (MacOS/Windows)
         if: runner.os != 'linux'
         uses: ./.github/actions/windows-mac
-

--- a/packaging/build_exe.py
+++ b/packaging/build_exe.py
@@ -105,9 +105,13 @@ def build_exe():
     shutil.rmtree(work_path)
 
     # Copy resources into installer directory
-    resources = ["static/images", "static/style.css"]
+    resources = ["static/images", "static/style.css", "../examples"]
     shutil.copy(PROJECT_PATH / "LICENSE", dist_path / "LICENSE")
     for resource in resources:
+        if resource == "../examples" and not IS_MAC:
+            # on macOS, examples have to go into resources
+            continue
+
         if IS_MAC:
             dest_path = dist_path / "rascal.app" / "Contents" / "Resources" / resource
         else:
@@ -127,9 +131,13 @@ def build_exe():
 
             ver_file.write(f'!define VERSION "{RASCAL2_VERSION}"')
 
-    arch_path = dist_path / "bin" / "_internal" / "matlab" / "engine" / "_arch.txt"
+    if IS_MAC:
+        arch_path = dist_path / "rascal.app" / "Contents" / "Resources" / "matlab" / "engine" / "_arch.txt"
+    else:
+        arch_path = dist_path / "bin" / "_internal" / "matlab" / "engine" / "_arch.txt"
+
     if arch_path.exists():
-        open(dist_path / "bin" / "_internal" / "matlab" / "engine" / "_arch.txt", "w").close()
+        open(arch_path, "w").close()
     else:
         warnings.warn(
             f"MATLAB engine arch file ({arch_path}) was not found. Ignore if you don't plan to use MATLAB",

--- a/packaging/build_exe.py
+++ b/packaging/build_exe.py
@@ -119,7 +119,7 @@ def build_exe():
             shutil.copytree(src_path, dest_path, ignore=shutil.ignore_patterns("__pycache__"))
 
     if IS_MAC:
-        shutil.rmtree(PACKAGING_PATH / "bundle" / "app" / "rascal")
+        shutil.rmtree(PACKAGING_PATH / "bundle" / "rascal")
 
     if IS_WINDOWS:
         with open(PACKAGING_PATH / "windows" / "version.nsh", "w") as ver_file:

--- a/packaging/build_exe.py
+++ b/packaging/build_exe.py
@@ -105,18 +105,19 @@ def build_exe():
     shutil.rmtree(work_path)
 
     # Copy resources into installer directory
-    resources = ["static/images", "static/style.css", "../examples"]
+    resources = ["static/images", "static/style.css"]
+    if IS_MAC:
+        # on macOS, examples have to go into resources
+        resources.append("../examples")
     shutil.copy(PROJECT_PATH / "LICENSE", dist_path / "LICENSE")
     for resource in resources:
-        if resource == "../examples" and not IS_MAC:
-            # on macOS, examples have to go into resources
-            continue
-
-        if IS_MAC:
-            dest_path = dist_path / "rascal.app" / "Contents" / "Resources" / resource
-        else:
-            dest_path = dist_path / resource
         src_path = PROJECT_PATH / "rascal2" / resource
+        dest_path = dist_path / resource
+        if IS_MAC:
+            if resource == "../examples":
+                resource = resource[3:]
+            dest_path = dist_path / "rascal.app" / "Contents" / "Resources" / resource
+
         if src_path.is_file():
             shutil.copy(src_path, dest_path)
         else:

--- a/packaging/macos/distribution.xml.in
+++ b/packaging/macos/distribution.xml.in
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="2">
+    <title>Rascal-2 @VERSION_NAME@</title>
+    <license file="LICENSE" mime-type="text/plain"/>
+    <pkg-ref id="com.rascal2.pkg.rascal"/>
+    <options customize="never" require-scripts="false" rootVolumeOnly="true" hostArchitectures="arm64,x86_64"/>
+    <choices-outline>
+        <line choice="com.rascal2.pkg.rascal"/>
+    </choices-outline>
+    <choice id="com.rascal2.pkg.rascal" title="RasCAL 2" enabled="false" start_selected="true">
+        <pkg-ref id="com.rascal2.pkg.rascal" version="@VERSION@" onConclusion="none">rascal.pkg</pkg-ref>
+    </choice>
+</installer-gui-script>

--- a/packaging/macos/make.sh
+++ b/packaging/macos/make.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+RASCAL_PATH="../bundle/rascal.app"
+VER_NAME=$1
+ARCH_NAME=$2
+VER=$VER_NAME
+
+if [[ ${VER_NAME:0:1} == 'v' ]]; then
+    VER=${VER:1}
+fi
+
+# Build Pkg
+sed -e "s/@VERSION_NAME@/${VER_NAME}/g" -e "s/@VERSION@/${VER}/g" distribution.xml.in > distribution.xml
+pkgbuild --root ${RASCAL_PATH} --identifier com.rascal2.rascal.pkg --version ${VER} --install-location "/Applications/rascal.app" rascal.pkg
+productbuild --distribution distribution.xml --resources . "rascal2-${VER}-${ARCH_NAME}.pkg"

--- a/rascal2/config.py
+++ b/rascal2/config.py
@@ -13,6 +13,8 @@ from rascal2.settings import get_global_settings
 if getattr(sys, "frozen", False):
     # we are running in a bundle
     SOURCE_PATH = pathlib.Path(sys.executable).parent.parent
+    if pathlib.Path(SOURCE_PATH / 'MacOS').is_dir():
+        SOURCE_PATH = SOURCE_PATH / 'Resources'
     SITE_PATH = SOURCE_PATH / "bin/_internal"
     EXAMPLES_PATH = SOURCE_PATH / "examples"
 else:

--- a/rascal2/config.py
+++ b/rascal2/config.py
@@ -13,9 +13,10 @@ from rascal2.settings import get_global_settings
 if getattr(sys, "frozen", False):
     # we are running in a bundle
     SOURCE_PATH = pathlib.Path(sys.executable).parent.parent
-    if pathlib.Path(SOURCE_PATH / 'MacOS').is_dir():
-        SOURCE_PATH = SOURCE_PATH / 'Resources'
     SITE_PATH = SOURCE_PATH / "bin/_internal"
+    if pathlib.Path(SOURCE_PATH / "MacOS").is_dir():
+        SOURCE_PATH = SOURCE_PATH / "Resources"
+        SITE_PATH = SOURCE_PATH
     EXAMPLES_PATH = SOURCE_PATH / "examples"
 else:
     SOURCE_PATH = pathlib.Path(__file__).parent
@@ -228,7 +229,7 @@ class MatlabHelper:
                 if len(lines) == 4:
                     install_dir = pathlib.Path(lines[1]).parent.parent
                 else:
-                    error = "Matlab not found, use 'Tools > Setup Matlab' to specify MATLAB location "
+                    error = "Matlab not found, specify MATLAB location in settings i.e. 'File > Settings' menu"
         except FileNotFoundError:
             error = "Matlab engine could not be found, ensure it is installed properly"
         if error:

--- a/rascal2/dialogs/settings_dialog.py
+++ b/rascal2/dialogs/settings_dialog.py
@@ -165,7 +165,10 @@ class MatlabSetupTab(QtWidgets.QWidget):
 
     def open_folder_selector(self) -> None:
         """Open folder selector."""
-        folder_name = QtWidgets.QFileDialog.getExistingDirectory(self, "Select MATLAB Directory", ".")
+        if platform.system() == "Darwin":
+            folder_name = QtWidgets.QFileDialog.getOpenFileName(self, "Select MATLAB Application", filter="(*.app)")[0]
+        else:
+            folder_name = QtWidgets.QFileDialog.getExistingDirectory(self, "Select MATLAB Directory", ".")
         if folder_name:
             self.matlab_path.setText(folder_name)
             self.changed = True
@@ -186,7 +189,13 @@ class MatlabSetupTab(QtWidgets.QWidget):
 
             path_file.truncate(0)
 
-            arch = "win64" if platform.system() == "Windows" else "glnxa64"
+            if platform.system() == "Windows":
+                arch = "win64"
+            elif platform.system() == "Darwin":
+                arch = "maca64" if platform.mac_ver()[-1] == "arm64" else "maci64"
+            else:
+                arch = "glnxa64"
+
             path_file.writelines(
                 [
                     f"{arch}\n",

--- a/rascal2/dialogs/settings_dialog.py
+++ b/rascal2/dialogs/settings_dialog.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 
 from PyQt6 import QtCore, QtWidgets
 
-from rascal2.config import MATLAB_ARCH_FILE, MatlabHelper
+from rascal2.config import LOGGER, MATLAB_ARCH_FILE, MatlabHelper
 from rascal2.settings import SettingsGroups
 from rascal2.widgets.inputs import get_validated_input
 
@@ -168,7 +168,9 @@ class MatlabSetupTab(QtWidgets.QWidget):
         if platform.system() == "Darwin":
             folder_name = QtWidgets.QFileDialog.getOpenFileName(self, "Select MATLAB Application", filter="(*.app)")[0]
         else:
-            folder_name = QtWidgets.QFileDialog.getExistingDirectory(self, "Select MATLAB Directory", self.matlab_path.text())
+            folder_name = QtWidgets.QFileDialog.getExistingDirectory(
+                self, "Select MATLAB Directory", self.matlab_path.text()
+            )
         if folder_name:
             self.matlab_path.setText(folder_name)
             self.changed = True
@@ -178,10 +180,11 @@ class MatlabSetupTab(QtWidgets.QWidget):
         if not self.changed:
             return
 
-        should_init = False
+        # should_init = False
         with suppress(FileNotFoundError), open(MATLAB_ARCH_FILE, "r+") as path_file:
             try:
                 install_dir = pathlib.Path(self.matlab_path.text())
+                LOGGER.info(f"install_dir: {install_dir}")
                 if not getattr(sys, "frozen", False):
                     return
 
@@ -195,7 +198,7 @@ class MatlabSetupTab(QtWidgets.QWidget):
                     arch = "maca64" if platform.mac_ver()[-1] == "arm64" else "maci64"
                 else:
                     arch = "glnxa64"
-
+                LOGGER.info(f"arch: {arch}")
                 path_file.writelines(
                     [
                         f"{arch}\n",
@@ -206,7 +209,6 @@ class MatlabSetupTab(QtWidgets.QWidget):
                 )
                 path_file.truncate()
             except Exception as ex:
-                import logging
-                logging.error("exception occurred", exc_info=ex)
+                LOGGER.error("exception occurred", exc_info=ex)
         # if should_init:
         MatlabHelper().async_start()

--- a/rascal2/dialogs/settings_dialog.py
+++ b/rascal2/dialogs/settings_dialog.py
@@ -136,7 +136,7 @@ class MatlabSetupTab(QtWidgets.QWidget):
         label_layout.addWidget(QtWidgets.QLabel("Current Matlab Directory:"))
         label_layout.addStretch(1)
         self.matlab_path = QtWidgets.QLineEdit(self)
-        self.matlab_path.setText(MatlabHelper().get_matlab_path())
+        self.matlab_path.setText(MatlabHelper().matlab_dir)
         self.matlab_path.setReadOnly(True)
         self.matlab_path.setPlaceholderText("Select MATLAB directory")
         self.matlab_path.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
@@ -180,28 +180,19 @@ class MatlabSetupTab(QtWidgets.QWidget):
         if not self.changed:
             return
 
-        # should_init = False
         with suppress(FileNotFoundError), open(MATLAB_ARCH_FILE, "r+") as path_file:
             try:
                 install_dir = pathlib.Path(self.matlab_path.text())
-                LOGGER.info(f"install_dir: {install_dir}")
                 if not getattr(sys, "frozen", False):
                     return
-
-                # if len(path_file.readlines()) == 0:
-                #     should_init = True
 
                 path_file.seek(0)
                 if platform.system() == "Windows":
                     arch = "win64"
                 elif platform.system() == "Darwin":
-                    if platform.mac_ver()[-1] == "arm64" and (install_dir / "bin/maca64").exists():
-                        arch = "maca64"
-                    else:
-                        arch = "maci64"
+                    arch = "maca64" if platform.mac_ver()[-1] == "arm64" else "maci64"
                 else:
                     arch = "glnxa64"
-                LOGGER.info(f"arch: {arch}")
                 path_file.writelines(
                     [
                         f"{arch}\n",
@@ -213,5 +204,5 @@ class MatlabSetupTab(QtWidgets.QWidget):
                 path_file.truncate()
             except Exception as ex:
                 LOGGER.error("exception occurred", exc_info=ex)
-        # if should_init:
+
         MatlabHelper().async_start()

--- a/rascal2/dialogs/settings_dialog.py
+++ b/rascal2/dialogs/settings_dialog.py
@@ -195,7 +195,10 @@ class MatlabSetupTab(QtWidgets.QWidget):
                 if platform.system() == "Windows":
                     arch = "win64"
                 elif platform.system() == "Darwin":
-                    arch = "maca64" if platform.mac_ver()[-1] == "arm64" else "maci64"
+                    if platform.mac_ver()[-1] == "arm64" and (install_dir / "bin/maca64").exists():
+                        arch = "maca64"
+                    else:
+                        arch = "maci64"
                 else:
                     arch = "glnxa64"
                 LOGGER.info(f"arch: {arch}")

--- a/rascal2/ui/view.py
+++ b/rascal2/ui/view.py
@@ -152,9 +152,8 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.settings_action = QtGui.QAction("Settings", self)
         self.settings_action.setStatusTip("Settings")
         self.settings_action.setIcon(QtGui.QIcon(path_for("settings.png")))
+        self.settings_action.setMenuRole(QtGui.QAction.MenuRole.PreferencesRole)
         self.settings_action.triggered.connect(lambda: self.show_settings_dialog())
-        self.settings_action.setEnabled(False)
-        self.disabled_elements.append(self.settings_action)
 
         self.open_help_action = QtGui.QAction("&Help", self)
         self.open_help_action.setStatusTip("Open Documentation")
@@ -169,13 +168,16 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.toggle_slider_action.setEnabled(False)
         self.disabled_elements.append(self.toggle_slider_action)
 
-        self.open_about_action = QtGui.QAction("&About", self)
-        self.open_about_action.setStatusTip("Report RAT version&info")
-        self.open_about_action.triggered.connect(self.open_about_info)
+        open_about_action = QtGui.QAction("&About", self)
+        open_about_action.setStatusTip(f"About {MAIN_WINDOW_TITLE}")
+        open_about_action.triggered.connect(self.open_about_info)
+        open_about_action.setMenuRole(QtGui.QAction.MenuRole.AboutQtRole)
+        self.open_about_action = open_about_action
 
         self.exit_action = QtGui.QAction("E&xit", self)
         self.exit_action.setStatusTip(f"Quit {MAIN_WINDOW_TITLE}")
         self.exit_action.setShortcut(QtGui.QKeySequence.StandardKey.Quit)
+        self.exit_action.setMenuRole(QtGui.QAction.MenuRole.QuitRole)
         self.exit_action.triggered.connect(self.close)
 
         # Window menu actions
@@ -202,10 +204,6 @@ class MainWindowView(QtWidgets.QMainWindow):
         self.clear_terminal_action = QtGui.QAction("Clear Terminal", self)
         self.clear_terminal_action.setStatusTip("Clear text in the terminal")
         self.clear_terminal_action.triggered.connect(self.terminal_widget.clear)
-
-        self.setup_matlab_action = QtGui.QAction("Setup MATLAB", self)
-        self.setup_matlab_action.setStatusTip("Set the path of the MATLAB executable")
-        self.setup_matlab_action.triggered.connect(lambda: self.show_settings_dialog(tab_name="Matlab"))
 
     def create_menus(self):
         """Add sub menus to the main menu bar."""
@@ -243,8 +241,6 @@ class MainWindowView(QtWidgets.QMainWindow):
         tools_menu.addAction(self.toggle_slider_action)
         tools_menu.addSeparator()
         tools_menu.addAction(self.clear_terminal_action)
-        tools_menu.addSeparator()
-        tools_menu.addAction(self.setup_matlab_action)
 
         help_menu = main_menu.addMenu("&Help")
         help_menu.addAction(self.open_about_action)

--- a/tests/ui/test_view.py
+++ b/tests/ui/test_view.py
@@ -187,7 +187,7 @@ def test_menu_element_present(test_view, submenu_name):
         ),
         ("&Edit", ["&Undo", "&Redo", "Undo &History"]),
         ("&Windows", ["Tile Windows", "Reset to Default", "Save Current Window Positions"]),
-        ("&Tools", ["Show &Sliders", "", "Clear Terminal", "", "Setup MATLAB"]),
+        ("&Tools", ["Show &Sliders", "", "Clear Terminal"]),
         ("&Help", ["&About", "&Help"]),
     ],
 )


### PR DESCRIPTION
Closes #102 
Add script to create installers for intel and ARM Macs
Removed the Setup MATLAB menu to avoid confusion (I don't full understand the behaviour bur MacOS tries to move the settings menu and would sometimes move this menu, sometimes the menu would be called preferences, other times it would be called settings)

https://github.com/user-attachments/assets/b85817af-ecb1-4a1d-9804-6701438a70c2