### PR TITLE
Makes all settings global

### DIFF
--- a/rascal2/config.py
+++ b/rascal2/config.py
@@ -24,6 +24,7 @@ STATIC_PATH = SOURCE_PATH / "static"
 IMAGES_PATH = STATIC_PATH / "images"
 MATLAB_ARCH_FILE = pathlib.Path(SITE_PATH) / "matlab/engine/_arch.txt"
 EXAMPLES_TEMP_PATH = pathlib.Path(get_global_settings().fileName()).parent / "examples"
+LOGGER = logging.getLogger("rascal2")
 
 
 def handle_scaling():
@@ -237,6 +238,5 @@ class MatlabHelper:
         if error:
             self.engine_output[:] = []
             self.engine_output.append(Exception(error))
-            logger = logging.getLogger("rascal_log")
-            logger.error(f"{error}. Attempt to read MATLAB _arch file failed {MATLAB_ARCH_FILE}.")
+            LOGGER.error(f"{error}. Attempt to read MATLAB _arch file failed {MATLAB_ARCH_FILE}.")
         return str(install_dir)

--- a/rascal2/config.py
+++ b/rascal2/config.py
@@ -8,7 +8,7 @@ import platform
 import site
 import sys
 
-from rascal2.settings import Settings, get_global_settings
+from rascal2.settings import get_global_settings
 
 if getattr(sys, "frozen", False):
     # we are running in a bundle
@@ -50,84 +50,41 @@ def path_for(filename: str):
     return (IMAGES_PATH / filename).as_posix()
 
 
-def setup_settings(project_path: str | os.PathLike) -> Settings:
-    """Set up the Settings object for the project.
-
-    Parameters
-    ----------
-    project_path : str or PathLike
-        The path to the current RasCAL-2 project.
-
-    Returns
-    -------
-    Settings
-        If a settings.json file already exists in the
-        RasCAL-2 project, returns a Settings object with
-        the settings defined there. Otherwise, returns a
-        (global) default Settings object.
-
-    """
-    filepath: pathlib.Path = pathlib.Path(project_path, "settings.json")
-    if filepath.is_file():
-        json = filepath.read_text()
-        return Settings.model_validate_json(json)
-    return Settings()
+def log_uncaught_exceptions(exc_type, exc_value, exc_traceback):
+    """Qt slots swallows exceptions but this ensures exceptions are logged."""
+    logging.critical("An unhandled exception occurred!", exc_info=(exc_type, exc_value, exc_traceback))
+    logging.shutdown()
+    sys.exit(1)
 
 
-def setup_logging(log_path: str | os.PathLike, terminal=None, level: int = logging.INFO) -> logging.Logger:
+def setup_logging(level: int = logging.INFO) -> None:
     """Set up logging for the project.
 
-    The default logging path and level are defined in the settings.
-
     Parameters
     ----------
-    log_path : str | PathLike
-        The path to where the log file will be written.
-    terminal : Optional[TerminalWidget]
-        The TerminalWidget instance which acts as an IO stream.
     level : int, default logging.INFO
         The debug level for the logger.
 
     """
-    path = pathlib.Path(log_path)
-    logger = logging.getLogger("rascal_log")
+    path = pathlib.Path(get_global_settings().fileName()).parent
+    path.mkdir(parents=True, exist_ok=True)
+
+    logger = logging.getLogger()
     logger.setLevel(level)
     logger.handlers.clear()
 
-    log_filehandler = logging.FileHandler(path)
+    log_file_handler = logging.FileHandler(path / "rascal.log")
     file_formatting = logging.Formatter("%(asctime)s - %(threadName)s -  %(name)s - %(levelname)s - %(message)s")
-    log_filehandler.setFormatter(file_formatting)
-    logger.addHandler(log_filehandler)
+    log_file_handler.setFormatter(file_formatting)
+    logger.addHandler(log_file_handler)
 
-    if terminal is not None:
-        # handler that logs to terminal widget
-        log_termhandler = logging.StreamHandler(stream=terminal)
-        term_formatting = logging.Formatter("%(levelname)s - %(message)s")
-        log_termhandler.setFormatter(term_formatting)
-        logger.addHandler(log_termhandler)
+    # handler that logs to terminal widget
+    log_term_handler = logging.StreamHandler()
+    term_formatting = logging.Formatter("%(levelname)s - %(message)s")
+    log_term_handler.setFormatter(term_formatting)
+    logger.addHandler(log_term_handler)
 
-    return logger
-
-
-def get_logger():
-    """Get the RasCAL logger, and set up a backup logger if it hasn't been set up yet."""
-    logger = logging.getLogger("rascal_log")
-    if not logger.handlers:
-        # Backup in case the crash happens before the local logger setup
-        path = pathlib.Path(get_global_settings().fileName()).parent
-        path.mkdir(parents=True, exist_ok=True)
-        setup_logging(path / "rascal.log")
-
-    return logger
-
-
-def log_uncaught_exceptions(exc_type, exc_value, exc_traceback):
-    """Qt slots swallows exceptions but this ensures exceptions are logged."""
-    logger = get_logger()
-    logger.addHandler(logging.StreamHandler(stream=sys.stderr))  # print emergency crashes to terminal
-    logger.critical("An unhandled exception occurred!", exc_info=(exc_type, exc_value, exc_traceback))
-    logging.shutdown()
-    sys.exit(1)
+    sys.excepthook = log_uncaught_exceptions
 
 
 def run_matlab(ready_event, close_event, engine_output):

--- a/rascal2/core/commands.py
+++ b/rascal2/core/commands.py
@@ -1,13 +1,14 @@
 """File for Qt commands."""
 
 import copy
-import logging
 from collections.abc import Callable
 from enum import IntEnum, unique
 
 import ratapi
 from PyQt6 import QtGui
 from ratapi import ClassList
+
+from rascal2.config import LOGGER
 
 
 @unique
@@ -69,7 +70,7 @@ class AbstractModelEdit(QtGui.QUndoCommand):
                 except Exception as ex:
                     self.new_result = self.old_result
                     message = f"Error occurred when generating result preview:\n\n{ex}"
-                    logging.error(message, exc_info=ex)
+                    LOGGER.error(message, exc_info=ex)
                     self.presenter.view.terminal_widget.write(message)
             self.presenter.model.update_results(self.new_result)
         else:

--- a/rascal2/dialogs/custom_file_editor.py
+++ b/rascal2/dialogs/custom_file_editor.py
@@ -1,12 +1,11 @@
 """Dialogs for editing custom files."""
 
-import logging
 from pathlib import Path
 
 from PyQt6 import Qsci, QtGui, QtWidgets
 from ratapi.utils.enums import Languages
 
-from rascal2.config import EXAMPLES_PATH, MatlabHelper
+from rascal2.config import EXAMPLES_PATH, LOGGER, MatlabHelper
 
 
 def edit_file(filename: str, language: Languages, parent: QtWidgets.QWidget):
@@ -24,8 +23,7 @@ def edit_file(filename: str, language: Languages, parent: QtWidgets.QWidget):
     """
     file = Path(filename)
     if not file.is_file():
-        logger = logging.getLogger("rascal_log")
-        logger.error("Attempted to edit a custom file which does not exist!")
+        LOGGER.error("Attempted to edit a custom file which does not exist!")
         return
 
     dialog = CustomFileEditorDialog(file, language, parent)
@@ -37,7 +35,7 @@ def edit_file_matlab(filename: str):
     try:
         engine = MatlabHelper().get_local_engine()
     except Exception as ex:
-        logging.error("Attempted to edit a file in MATLAB engine", exc_info=ex)
+        LOGGER.error("Attempted to edit a file in MATLAB engine", exc_info=ex)
         return
 
     engine.edit(str(filename))
@@ -131,5 +129,5 @@ class CustomFileEditorDialog(QtWidgets.QDialog):
             self.accept()
         except OSError as ex:
             message = f"Failed to save custom file to {self.file}.\n"
-            logging.error(message, exc_info=ex)
+            LOGGER.error(message, exc_info=ex)
             QtWidgets.QMessageBox.critical(self, "Save File", message, QtWidgets.QMessageBox.StandardButton.Ok)

--- a/rascal2/dialogs/custom_file_editor.py
+++ b/rascal2/dialogs/custom_file_editor.py
@@ -37,8 +37,7 @@ def edit_file_matlab(filename: str):
     try:
         engine = MatlabHelper().get_local_engine()
     except Exception as ex:
-        logger = logging.getLogger("rascal_log")
-        logger.error("Attempted to edit a file in MATLAB engine" + repr(ex))
+        logging.error("Attempted to edit a file in MATLAB engine", exc_info=ex)
         return
 
     engine.edit(str(filename))
@@ -131,7 +130,6 @@ class CustomFileEditorDialog(QtWidgets.QDialog):
             self.file.write_text(self.editor.text())
             self.accept()
         except OSError as ex:
-            logger = logging.getLogger("rascal_log")
             message = f"Failed to save custom file to {self.file}.\n"
-            logger.error(message, exc_info=ex)
+            logging.error(message, exc_info=ex)
             QtWidgets.QMessageBox.critical(self, "Save File", message, QtWidgets.QMessageBox.StandardButton.Ok)

--- a/rascal2/dialogs/settings_dialog.py
+++ b/rascal2/dialogs/settings_dialog.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from PyQt6 import QtCore, QtWidgets
 
 from rascal2.config import MATLAB_ARCH_FILE, MatlabHelper
-from rascal2.settings import Settings, SettingsGroups, delete_local_settings
+from rascal2.settings import SettingsGroups
 from rascal2.widgets.inputs import get_validated_input
 
 
@@ -61,15 +61,13 @@ class SettingsDialog(QtWidgets.QDialog):
     def update_settings(self) -> None:
         """Accept the changed settings."""
         self.parent().settings = self.settings
-        if self.parent().presenter.model.save_path:
-            self.parent().settings.save(self.parent().presenter.model.save_path)
+        self.parent().settings.set_global_settings()
         self.matlab_tab.set_matlab_paths()
         self.accept()
 
     def reset_default_settings(self) -> None:
         """Reset the settings to the global defaults."""
-        delete_local_settings(self.parent().presenter.model.save_path)
-        self.parent().settings = Settings()
+        self.parent().settings.reset_global_settings()
         self.accept()
 
 

--- a/rascal2/dialogs/startup_dialog.py
+++ b/rascal2/dialogs/startup_dialog.py
@@ -1,10 +1,9 @@
-import logging
 import os
 from pathlib import Path
 
 from PyQt6 import QtCore, QtWidgets
 
-from rascal2.config import EXAMPLES_PATH
+from rascal2.config import EXAMPLES_PATH, LOGGER
 from rascal2.core.worker import Worker
 from rascal2.settings import update_recent_projects
 
@@ -183,7 +182,7 @@ class StartupDialog(QtWidgets.QDialog):
         folder_name = args[0]
         error = str(exception).strip().replace("\n", "")
         message = f"The Project ({folder_name}) could not be opened because:\n\n{error}"
-        logging.error(message, exc_info=exception)
+        LOGGER.error(message, exc_info=exception)
         QtWidgets.QMessageBox.critical(self, self.windowTitle(), message)
 
 

--- a/rascal2/main.py
+++ b/rascal2/main.py
@@ -1,3 +1,4 @@
+import logging
 import multiprocessing
 import re
 import sys
@@ -5,7 +6,7 @@ from contextlib import suppress
 
 from PyQt6 import QtGui, QtWidgets
 
-from rascal2.config import IMAGES_PATH, STATIC_PATH, MatlabHelper, handle_scaling, log_uncaught_exceptions, path_for
+from rascal2.config import IMAGES_PATH, STATIC_PATH, MatlabHelper, handle_scaling, path_for, setup_logging
 from rascal2.ui.view import MainWindowView
 
 
@@ -42,10 +43,11 @@ def main():
     """Entry point function for starting RasCAL."""
     multiprocessing.freeze_support()
     multiprocessing.set_start_method("spawn", force=True)
-    sys.excepthook = log_uncaught_exceptions
+    setup_logging()
     matlab_helper = MatlabHelper()
     exit_code = ui_execute()
     matlab_helper.close_event.set()
+    logging.shutdown()
     sys.exit(exit_code)
 
 

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import warnings
 from typing import Any
@@ -71,11 +72,10 @@ class MainWindowPresenter:
 
     def initialise_ui(self):
         """Initialise UI for a project."""
-        suffix = " [Example]" if self.model.is_project_example() else ""
+        suffix = " [Example]" if self.model.is_project_example() else f"[{self.model.save_path}]"
         self.view.setWindowTitle(
             self.view.windowTitle().split(" - ")[0] + " - " + self.model.project.name + suffix,
         )
-        self.view.init_settings_and_log(self.model.save_path)
         self.view.setup_mdi()
         self.view.plot_widget.update_plots()
         self.view.handle_results(self.model.results)
@@ -124,7 +124,7 @@ class MainWindowPresenter:
         try:
             self.model.save_project(to_path)
         except OSError as err:
-            self.view.logging.error(f"Failed to save project to {to_path}.\n", exc_info=err)
+            logging.error(f"Failed to save project to {to_path}.\n", exc_info=err)
         else:
             update_recent_projects(self.model.save_path)
             self.view.undo_stack.setClean()
@@ -158,7 +158,7 @@ class MainWindowPresenter:
         try:
             write_result_to_zipped_csvs(save_file, results)
         except OSError as err:
-            self.view.logging.error(f"Failed to save fits to {save_file}.\n", exc_info=err)
+            logging.error(f"Failed to save fits to {save_file}.\n", exc_info=err)
 
     def interrupt_terminal(self):
         """Send an interrupt signal to the RAT runner."""
@@ -232,9 +232,9 @@ class MainWindowPresenter:
     def handle_interrupt(self):
         """Handle a RAT run being interrupted."""
         if self.runner.error is None:
-            self.view.logging.info("RAT run interrupted!")
+            logging.info("RAT run interrupted!")
         else:
-            self.view.logging.error("RAT run failed with exception.\n", exc_info=self.runner.error)
+            logging.error("RAT run failed with exception.\n", exc_info=self.runner.error)
         self.view.handle_results()
         self.model.controls.delete_IPC()
 
@@ -252,7 +252,7 @@ class MainWindowPresenter:
             case rat.events.PlotEventData():
                 self.view.plot_widget.plot_with_blit(event)
             case LogData():
-                self.view.logging.log(event.level, event.msg)
+                logging.log(event.level, event.msg)
 
     def edit_project(self, updated_project: dict, preview: bool = True) -> None:
         """Edit the Project with a dictionary of attributes.

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import warnings
 from typing import Any
@@ -6,7 +5,7 @@ from typing import Any
 import ratapi as rat
 import ratapi.wrappers
 
-from rascal2.config import MatlabHelper, get_matlab_engine
+from rascal2.config import LOGGER, MatlabHelper, get_matlab_engine
 from rascal2.core import commands
 from rascal2.core.enums import UnsavedReply
 from rascal2.core.runner import LogData, RATRunner
@@ -124,7 +123,7 @@ class MainWindowPresenter:
         try:
             self.model.save_project(to_path)
         except OSError as err:
-            logging.error(f"Failed to save project to {to_path}.\n", exc_info=err)
+            LOGGER.error(f"Failed to save project to {to_path}.\n", exc_info=err)
         else:
             update_recent_projects(self.model.save_path)
             self.view.undo_stack.setClean()
@@ -158,7 +157,7 @@ class MainWindowPresenter:
         try:
             write_result_to_zipped_csvs(save_file, results)
         except OSError as err:
-            logging.error(f"Failed to save fits to {save_file}.\n", exc_info=err)
+            LOGGER.error(f"Failed to save fits to {save_file}.\n", exc_info=err)
 
     def interrupt_terminal(self):
         """Send an interrupt signal to the RAT runner."""
@@ -232,9 +231,9 @@ class MainWindowPresenter:
     def handle_interrupt(self):
         """Handle a RAT run being interrupted."""
         if self.runner.error is None:
-            logging.info("RAT run interrupted!")
+            LOGGER.info("RAT run interrupted!")
         else:
-            logging.error("RAT run failed with exception.\n", exc_info=self.runner.error)
+            LOGGER.error("RAT run failed with exception.\n", exc_info=self.runner.error)
         self.view.handle_results()
         self.model.controls.delete_IPC()
 
@@ -252,7 +251,7 @@ class MainWindowPresenter:
             case rat.events.PlotEventData():
                 self.view.plot_widget.plot_with_blit(event)
             case LogData():
-                logging.log(event.level, event.msg)
+                LOGGER.log(event.level, event.msg)
 
     def edit_project(self, updated_project: dict, preview: bool = True) -> None:
         """Edit the Project with a dictionary of attributes.

--- a/rascal2/widgets/plot.py
+++ b/rascal2/widgets/plot.py
@@ -12,6 +12,17 @@ from rascal2.config import path_for
 from rascal2.widgets.inputs import MultiSelectComboBox, ProgressButton
 
 
+class CanvasQT(FigureCanvasQTAgg):
+    """Workaround so plot window can be started minimised."""
+
+    def showEvent(self, event):
+        # Calling showMinimised in reset_mdi_layout causes a crash because window
+        # handle can be None.
+        window = self.window().windowHandle()
+        if window is not None:
+            super().showEvent(event)
+
+
 class PlotWidget(QtWidgets.QWidget):
     """The MDI plot widget."""
 
@@ -212,7 +223,7 @@ class AbstractPlotWidget(QtWidgets.QWidget):
 
         self.blit_plot = None
         self.figure = self.make_figure()
-        self.canvas = FigureCanvasQTAgg(
+        self.canvas = CanvasQT(
             self.figure,
         )
         self.figure.set_facecolor("none")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,40 @@
-import pytest
-from PyQt6.QtWidgets import QApplication
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
 
-APP = QApplication([])
+import pytest
+from PyQt6 import QtCore, QtWidgets
+
+APP = QtWidgets.QApplication([])
+GLOBAL_SETTING = None
 
 
 @pytest.fixture
 def qt_application():
     return APP
+
+
+@pytest.fixture
+def global_setting():
+    return GLOBAL_SETTING
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_setting(request):
+    global GLOBAL_SETTING
+    tmp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    ini_file = Path(tmp_dir.name) / "settings.ini"
+    GLOBAL_SETTING = QtCore.QSettings(str(ini_file), QtCore.QSettings.Format.IniFormat)
+    setting_patch = []
+    for target in ["rascal2.ui.view.get_global_settings", "rascal2.settings.get_global_settings"]:
+        setting_patch.append(patch(target, return_value=GLOBAL_SETTING))
+        setting_patch[-1].start()
+
+    def teardown_mock_setting():
+        global GLOBAL_SETTING
+        GLOBAL_SETTING = None
+        tmp_dir.cleanup()
+        for target in setting_patch:
+            target.stop()
+
+    request.addfinalizer(teardown_mock_setting)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -10,12 +10,12 @@ def make_main_window(request):
     def make():
         no_exceptions = True
 
-        def test_exception_hook(exc_type, exc_value, exc_traceback):
+        def exception_hook(exc_type, exc_value, exc_traceback):
             nonlocal no_exceptions
             no_exceptions = False
             sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
-        sys.excepthook = test_exception_hook
+        sys.excepthook = exception_hook
 
         window = MainWindowView()
 

--- a/tests/ui/test_presenter.py
+++ b/tests/ui/test_presenter.py
@@ -47,14 +47,14 @@ class MockWindowView(QtWidgets.QMainWindow):
 
 @pytest.fixture
 def presenter():
-    with patch("rascal2.ui.presenter.logging", autospec=True) as mock_log:
+    with patch("rascal2.ui.presenter.LOGGER", autospec=True) as mock_log:
         pr = MainWindowPresenter(MockWindowView())
         pr.runner = MagicMock()
         pr.model.controls = Controls()
         pr.model.project = MagicMock()
         pr.model.results = MagicMock()
         pr.model.save_path = "some_path/"
-        pr.logging = mock_log
+        pr.logger = mock_log
 
         yield pr
 
@@ -128,7 +128,7 @@ def test_stop_run(presenter):
     presenter.runner = MagicMock()
     presenter.runner.error = None
     presenter.handle_interrupt()
-    presenter.logging.info.assert_called_once_with("RAT run interrupted!")
+    presenter.logger.info.assert_called_once_with("RAT run interrupted!")
 
 
 def test_run_error(presenter):
@@ -136,7 +136,7 @@ def test_run_error(presenter):
     presenter.runner = MagicMock()
     presenter.runner.error = ValueError("Test error!")
     presenter.handle_interrupt()
-    presenter.logging.error.assert_called_once_with("RAT run failed with exception.\n", exc_info=presenter.runner.error)
+    presenter.logger.error.assert_called_once_with("RAT run failed with exception.\n", exc_info=presenter.runner.error)
 
 
 @pytest.mark.parametrize(
@@ -169,7 +169,7 @@ def test_handle_progress_event(presenter):
 def test_handle_log_data(presenter):
     presenter.runner.events = [LogData(10, "Test log!")]
     presenter.handle_event()
-    presenter.logging.log.assert_called_with(10, "Test log!")
+    presenter.logger.log.assert_called_with(10, "Test log!")
 
 
 @pytest.mark.parametrize("function", ["create_project", "load_project", "load_r1_project"])
@@ -250,11 +250,11 @@ def test_export_fits(mock_write_result, presenter):
     error = OSError("Test Error")
     mock_write_result.side_effect = error
     presenter.view.get_save_file = MagicMock(return_value=test_zip_file)
-    presenter.logging.error = MagicMock()
+    presenter.logger.error = MagicMock()
 
     presenter.export_fits()
     mock_write_result.assert_called_once_with(test_zip_file, presenter.model.results)
-    presenter.logging.error.assert_called_once_with("Failed to save fits to test.zip.\n", exc_info=error)
+    presenter.logger.error.assert_called_once_with("Failed to save fits to test.zip.\n", exc_info=error)
 
     # If we do not have any results, don't ask for a file
     presenter.view.get_save_file.reset_mock()

--- a/tests/ui/test_presenter.py
+++ b/tests/ui/test_presenter.py
@@ -41,21 +41,22 @@ class MockWindowView(QtWidgets.QMainWindow):
         self.terminal_widget = MagicMock()
         self.plot_widget = MagicMock()
         self.handle_results = MagicMock()
-        self.logging = MagicMock()
         self.settings = MagicMock()
         self.get_project_folder = lambda: "new path/"
 
 
 @pytest.fixture
 def presenter():
-    pr = MainWindowPresenter(MockWindowView())
-    pr.runner = MagicMock()
-    pr.model.controls = Controls()
-    pr.model.project = MagicMock()
-    pr.model.results = MagicMock()
-    pr.model.save_path = "some_path/"
+    with patch("rascal2.ui.presenter.logging", autospec=True) as mock_log:
+        pr = MainWindowPresenter(MockWindowView())
+        pr.runner = MagicMock()
+        pr.model.controls = Controls()
+        pr.model.project = MagicMock()
+        pr.model.results = MagicMock()
+        pr.model.save_path = "some_path/"
+        pr.logging = mock_log
 
-    return pr
+        yield pr
 
 
 @pytest.mark.parametrize(["param", "value"], [("nSamples", 50), ("parallel", "contrasts")])
@@ -127,7 +128,7 @@ def test_stop_run(presenter):
     presenter.runner = MagicMock()
     presenter.runner.error = None
     presenter.handle_interrupt()
-    presenter.view.logging.info.assert_called_once_with("RAT run interrupted!")
+    presenter.logging.info.assert_called_once_with("RAT run interrupted!")
 
 
 def test_run_error(presenter):
@@ -135,9 +136,7 @@ def test_run_error(presenter):
     presenter.runner = MagicMock()
     presenter.runner.error = ValueError("Test error!")
     presenter.handle_interrupt()
-    presenter.view.logging.error.assert_called_once_with(
-        "RAT run failed with exception.\n", exc_info=presenter.runner.error
-    )
+    presenter.logging.error.assert_called_once_with("RAT run failed with exception.\n", exc_info=presenter.runner.error)
 
 
 @pytest.mark.parametrize(
@@ -170,12 +169,11 @@ def test_handle_progress_event(presenter):
 def test_handle_log_data(presenter):
     presenter.runner.events = [LogData(10, "Test log!")]
     presenter.handle_event()
-    presenter.view.logging.log.assert_called_with(10, "Test log!")
+    presenter.logging.log.assert_called_with(10, "Test log!")
 
 
 @pytest.mark.parametrize("function", ["create_project", "load_project", "load_r1_project"])
-@patch("rascal2.ui.presenter.MainWindowModel", autospec=True)
-def test_load_project(model_mock, presenter, function):
+def test_load_project(presenter, function):
     """All the project initialisation functions should run the corresponding model function and initialise UI."""
     end_function = MagicMock()
     setattr(presenter.model, function, MagicMock())
@@ -252,11 +250,11 @@ def test_export_fits(mock_write_result, presenter):
     error = OSError("Test Error")
     mock_write_result.side_effect = error
     presenter.view.get_save_file = MagicMock(return_value=test_zip_file)
-    presenter.view.logging.error = MagicMock()
+    presenter.logging.error = MagicMock()
 
     presenter.export_fits()
     mock_write_result.assert_called_once_with(test_zip_file, presenter.model.results)
-    presenter.view.logging.error.assert_called_once_with("Failed to save fits to test.zip.\n", exc_info=error)
+    presenter.logging.error.assert_called_once_with("Failed to save fits to test.zip.\n", exc_info=error)
 
     # If we do not have any results, don't ask for a file
     presenter.view.get_save_file.reset_mock()


### PR DESCRIPTION
- Fixes #177 
- Also fixes the **Windows > Save Current Windows Positions** option, now if you move the mdi windows and save, the windows will be put into the same position when reopening the software or when **Reset to default** is clicked 
- Refactors logging and adds a custom stream handler so the terminal formats errors properly

  ```
  logging.info("Blah Blah!!")
  logging.error("Blah Blah to you too!!")
  ```
  
  <img width="1138" height="544" alt="Screenshot 2026-01-21 103030" src="https://github.com/user-attachments/assets/7bc5cdba-df80-4901-8a0b-f8926d9a6d89" />
