### PR TITLE
Unifies naming style for installers

### DIFF
--- a/.github/workflows/build_installer.yaml
+++ b/.github/workflows/build_installer.yaml
@@ -31,7 +31,12 @@ jobs:
           conda install -c nsis nsis=3.* accesscontrol
           pip install matlabengine==9.14.*
           python packaging/build_exe.py
-          makensis packaging/windows/build_installer.nsi
+          if ($env:GITHUB_REF_NAME -eq "main") {
+            makensis /DNIGHTLY packaging/windows/build_installer.nsi
+          }
+          else {
+            makensis packaging/windows/build_installer.nsi
+          }
       - name: Upload installer
         uses: actions/upload-artifact@v4
         with:
@@ -90,7 +95,7 @@ jobs:
           if [ ${{ matrix.platform }} == "macos-14" ]; then
             ARCH="arm64"
             export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/bin/maca64
-            python -m pip install --no-build-isolation /Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/extern/engines/python    
+            python -m pip install --no-build-isolation /Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/extern/engines/python
           else
             ARCH="x64"
             export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/runner/hostedtoolcache/MATLAB/2023.2.999/x64/MATLAB.app/bin/maci64
@@ -105,7 +110,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macOS installer-${{ strategy.job-index }}
-          path: packaging/macos/rascal2-*.pkg
+          path: packaging/macos/RasCAL-2*.pkg
   deploy-nightly:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/packaging/linux/build_installer.sh
+++ b/packaging/linux/build_installer.sh
@@ -151,9 +151,9 @@ chmod 777 "$STAGE_DIR/rascal/packaging/linux/install.sh"
 echo ""
 echo "Creating self-extracting archive"
 echo ""
-EXECUTABLE="RasCAL-2-installer.run"
+EXECUTABLE="RasCAL-2-linux.run"
 if [ -n "$TAG" ]; then
-  EXECUTABLE="RasCAL-2-${TAG:1}-installer.run"
+  EXECUTABLE="RasCAL-2-${TAG:1}-linux.run"
 fi
 
 makeself --tar-format "posix" --tar-extra "--exclude=__pycache__ --exclude=.git --exclude=.github --exclude=rascal/doc --exclude=rascal/tests" "$STAGE_DIR" "$EXECUTABLE" "RasCAL-2 installer" ./rascal/packaging/linux/install.sh

--- a/packaging/macos/make.sh
+++ b/packaging/macos/make.sh
@@ -3,13 +3,19 @@
 RASCAL_PATH="../bundle/rascal.app"
 VER_NAME=$1
 ARCH_NAME=$2
-VER=$VER_NAME
+VER="main"
 
 if [[ ${VER_NAME:0:1} == 'v' ]]; then
     VER=${VER:1}
 fi
 
+if [[ ${VER} == 'main' ]]; then
+    NAME="RasCAL-2-macos-${ARCH_NAME}.pkg"
+else
+    NAME="RasCAL-2-${VER}-macos-${ARCH_NAME}.pkg"
+fi
+
 # Build Pkg
 sed -e "s/@VERSION_NAME@/${VER_NAME}/g" -e "s/@VERSION@/${VER}/g" distribution.xml.in > distribution.xml
 pkgbuild --root ${RASCAL_PATH} --identifier com.rascal2.rascal.pkg --version ${VER} --install-location "/Applications/rascal.app" rascal.pkg
-productbuild --distribution distribution.xml --resources . "rascal2-${VER}-${ARCH_NAME}.pkg"
+productbuild --distribution distribution.xml --resources . ${NAME}

--- a/packaging/windows/build_installer.nsi
+++ b/packaging/windows/build_installer.nsi
@@ -11,11 +11,16 @@
 Unicode true
 
 ;Define name of the product
-!define PRODUCT "RasCAL 2"
+!define PRODUCT "RasCAL-2"
 
 ;Name and file
 Name "${PRODUCT}"
-OutFile "${PRODUCT}-${VERSION}-setup.exe"
+
+!ifdef NIGHTLY
+    OutFile "${PRODUCT}-windows.exe"
+!else
+    OutFile "${PRODUCT}-${VERSION}-windows.exe"
+!endif
 
 ;Default installation folder
 InstallDir "$PROGRAMFILES64\${PRODUCT}"

--- a/rascal2/config.py
+++ b/rascal2/config.py
@@ -246,7 +246,9 @@ class MatlabHelper:
                     )
         except (FileNotFoundError, MatlabHelper.ConfigError) as ex:
             if isinstance(ex, FileNotFoundError):
-                ex.add_note("Matlab engine could not be found, ensure it is installed properly.")
+                ex = MatlabHelper.ConfigError(
+                    "Matlab engine could not be found, ensure it is installed properly."
+                ).with_traceback(ex.__traceback__)
             self.engine_output[:] = []
             self.engine_output.append(ex)
             LOGGER.error(f"Attempt to read MATLAB _arch file failed {MATLAB_ARCH_FILE}.\n {ex}.")


### PR DESCRIPTION
This makes it easier to know which OS the installer is for. Installer will now be 

RasCAL-2-{os_name} for nightly 

or 

RasCAL-2-{Ver}-{os_name} for release

We will need to update on IDAaas so it continues to pull the correct file.

Also fixes bug in config, `add_note` is only available from 3.11