### PR TITLE
Fix formatting text after an Error in the Terminal

### DIFF
--- a/rascal2/widgets/terminal.py
+++ b/rascal2/widgets/terminal.py
@@ -97,7 +97,7 @@ class TerminalWidget(QtWidgets.QWidget):
 
     def clear(self):
         """Clear the text in the terminal."""
-        self.write_html('<div style="color: black;white-space: pre-line;"><b>" "</b></div>')
+        self.write_html('<div style="white-space: pre-line;"><b>" "</b></div>')
         self.text_area.moveCursor(QtGui.QTextCursor.MoveOperation.Start, QtGui.QTextCursor.MoveMode.MoveAnchor)
         self.text_area.setPlainText("")
         self.update()

--- a/rascal2/widgets/terminal.py
+++ b/rascal2/widgets/terminal.py
@@ -97,6 +97,8 @@ class TerminalWidget(QtWidgets.QWidget):
 
     def clear(self):
         """Clear the text in the terminal."""
+        self.write_html('<div style="color: black;white-space: pre-line;"><b>" "</b></div>')
+        self.text_area.moveCursor(QtGui.QTextCursor.MoveOperation.Start, QtGui.QTextCursor.MoveMode.MoveAnchor)
         self.text_area.setPlainText("")
         self.update()
 


### PR DESCRIPTION
This PR fixes an issue in the Terminal where if an Error was produced via the Custom File and then the red text in the Termain was clicked (moving the invisible cursor), then all text in the Terminal will now be red, even if the Error is corrected. 

To produce the issue in main:

1. Open Domain Custom XY [Example]
2. Edit the domains_XY_model.py custom file
3. Edit it to force an issue, e.g. def domains_XY_model(params, bulk_in, bulk_out, contrast, domain): -> def domains_XY_model(params, bulk_in, bulk_out, contrast, domain) and click save and Accept Changes in the Project Window.
4. Click on the red text in the Terminal MDI.
5. Click run.
All text in the Terminal will now be red.

This is fixed by when clearing the Terminal via `TerminalWidget.clear()`, we move the cursor onto some black HTML text before clearing the text and resetting the colour of the text.
Repeat the steps above on this branch to check that it fixes the formatting error.