### PR TITLE
Windows build fix

### DIFF
--- a/.github/workflows/build_installer.yaml
+++ b/.github/workflows/build_installer.yaml
@@ -29,7 +29,7 @@ jobs:
           conda init powershell
           conda activate rascal2
           conda install -c nsis nsis=3.* accesscontrol
-          python -m pip install --no-build-isolation 'D:\hostedtoolcache\windows\MATLAB\extern\engines\python'
+          python -m pip install --no-build-isolation matlabengine==9.14.*
           python packaging/build_exe.py
           if ($env:GITHUB_REF_NAME -eq "main") {
             makensis /DNIGHTLY packaging/windows/build_installer.nsi
@@ -94,13 +94,19 @@ jobs:
           conda activate rascal2
           if [ ${{ matrix.platform }} == "macos-14" ]; then
             ARCH="arm64"
-            export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/bin/maca64
-            python -m pip install --no-build-isolation /Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/extern/engines/python
+            MATLAB_DIR="/Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/bin/maca64"
+            ENGINE_DIR="/Users/runner/hostedtoolcache/MATLAB/2023.2.999/arm64/MATLAB.app/extern/engines/python"
+          
           else
             ARCH="x64"
-            export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/Users/runner/hostedtoolcache/MATLAB/2023.2.999/x64/MATLAB.app/bin/maci64
-            python -m pip install --no-build-isolation /Users/runner/hostedtoolcache/MATLAB/2023.2.999/x64/MATLAB.app/extern/engines/python
+            MATLAB_DIR="/Users/runner/hostedtoolcache/MATLAB/2023.2.999/x64/MATLAB.app/bin/maci64"
+            ENGINE_DIR="/Users/runner/hostedtoolcache/MATLAB/2023.2.999/x64/MATLAB.app/extern/engines/python"
           fi
+          if [ ! -d "${MATLAB_DIR}" ]; then
+            echo "MATLAB directory not found!"
+          fi
+          export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$MATLAB_DIR
+          python -m pip install --no-build-isolation $ENGINE_DIR
           python packaging/build_exe.py
           chmod 777 packaging/bundle/rascal.app/Contents/Resources/matlab/engine/_arch.txt
           cd packaging/macos/

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,8 +6,8 @@ dependencies:
   - python=3.10
   - pip
   - llvm-openmp
-  - expat=2.7.3
   - openssl=3.6.2
+  - expat=2.5.0
   - pip:
     - -r requirements.txt
     - -r requirements-dev.txt

--- a/rascal2/widgets/terminal.py
+++ b/rascal2/widgets/terminal.py
@@ -38,6 +38,8 @@ class TerminalWidget(QtWidgets.QWidget):
         font.setStyleHint(font.StyleHint.Monospace)
         self.text_area.setFont(font)
         self.text_area.setLineWrapMode(self.text_area.LineWrapMode.NoWrap)
+        self.text_format = QtGui.QTextCharFormat(self.text_area.currentCharFormat())
+        self.text_format.setFontWeight(QtGui.QFont.Weight.Bold)
 
         widget_layout = QtWidgets.QVBoxLayout()
 
@@ -72,6 +74,7 @@ class TerminalWidget(QtWidgets.QWidget):
             The text to append.
 
         """
+        self.text_area.setCurrentCharFormat(self.text_format)
         self.text_area.appendPlainText(text.rstrip())
 
     def write_html(self, text: str):
@@ -98,8 +101,7 @@ class TerminalWidget(QtWidgets.QWidget):
 
     def clear(self):
         """Clear the text in the terminal."""
-        self.write_html('<div style="white-space: pre-line;"><b>" "</b></div>')
-        self.text_area.moveCursor(QtGui.QTextCursor.MoveOperation.Start, QtGui.QTextCursor.MoveMode.MoveAnchor)
+        self.text_area.setCurrentCharFormat(self.text_format)
         self.text_area.setPlainText("")
         self.update()
 


### PR DESCRIPTION
The MATLAB action changed their install directory on Windows server which caused the matlabengine install to fail quietly and not bundle into the installer. This PR refactors the build script and adds checks for MATLAB paths, also downgrades expat because there was a conflict on windows because matlabengine uses an older version than the pinned one.

The error formatting bug still happens if an exception happened when loading a bad project then the user proceeds to load a good project so this also adds a fix

<img width="1025" height="624" alt="Screenshot 2026-06-23 120645" src="https://github.com/user-attachments/assets/90796519-48ae-48fc-8e35-60e556d9d6c2" />
