### PR TITLE
Speed up RAT calculations in python

### DIFF
--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -1,10 +1,9 @@
 """QObject for running rat."""
 
 import os
-import time
 from dataclasses import dataclass
 from logging import INFO
-from multiprocessing import Process, Queue, cpu_count, Event
+from multiprocessing import Event, Process, Queue, cpu_count
 
 import ratapi as rat
 from PyQt6 import QtCore
@@ -21,14 +20,14 @@ class RATRunner(QtCore.QObject):
     go_event = Event()
     processes_list_go_exit_events = []
 
-    def __init__(self, parent=None, start_runners_early: bool = True):
+    def __init__(self, parent=None, start_runners_early: bool = True, num_cores: int = cpu_count()):
         super().__init__()
         self.parent = parent
         self.timer = QtCore.QTimer()
         self.timer.setInterval(1)
         self.timer.timeout.connect(self.check_queue)
         self.matlab_helper = MatlabHelper()
-        self.num_cores = cpu_count()
+        self.num_cores = num_cores
         self.start_runners_early = start_runners_early
 
         # this queue handles both event data and results
@@ -36,7 +35,6 @@ class RATRunner(QtCore.QObject):
         self.arg_queue = Queue()
         self.go_event = Event()
         self.exit_event = Event()
-        # self.processes_list_go_exit_events = [(Event(), Event()) for _ in range(self.num_cores)]
         self.rat_inputs = None
         self.procedure = None
         self.display_on = None
@@ -47,17 +45,18 @@ class RATRunner(QtCore.QObject):
         self.results = None
         self.error = None
         self.events = []
+        self.engine_future = None
 
     def set_runner_args(self, rat_inputs, procedure, display_on: bool):
         self.arg_queue.put((rat_inputs, procedure, display_on))
+        self.rat_inputs = rat_inputs
+        self.display_on = display_on
 
     def start(self):
-        print("========= START =================")
         """Start the calculation."""
         self.process, (self.go_event, self.exit_event) = self.get_new_process()
-        print(self.process)
-        print(self.go_event)
-        print(self.exit_event)
+        if self.engine_future is None:
+            self.get_runner_matlab_engine()
         self.go_event.set()
         self.timer.start()
 
@@ -65,6 +64,19 @@ class RATRunner(QtCore.QObject):
         if not self.processes_list:
             self.refresh_process_list()
         return self.processes_list.pop(0), self.processes_list_go_exit_events.pop(0)
+
+    def get_runner_matlab_engine(self):
+        problem_definition, cpp_controls = self.rat_inputs
+        if any([file["language"] == "matlab" for file in problem_definition.customFiles.files]):
+            engine_ready = (self.matlab_helper.ready_event,)
+            engine_output = self.matlab_helper.engine_output
+            matlab_queue = Queue()
+            get_runner_matlab_engine_process = Process(
+                target=run_matlab_init_engine,
+                args=(matlab_queue, engine_output, engine_ready, self.display_on),
+            )
+            get_runner_matlab_engine_process.start()
+            self.engine_future = self.filter_queue(matlab_queue)
 
     def interrupt(self):
         """Interrupt the running process."""
@@ -77,8 +89,11 @@ class RATRunner(QtCore.QObject):
         """Check for new data in the queue."""
         if not self.process.is_alive():
             self.timer.stop()
-        self.queue.put(None)
-        for item in iter(self.queue.get, None):
+        self.filter_queue(self.queue)
+
+    def filter_queue(self, queue: Queue):
+        queue.put(None)
+        for item in iter(queue.get, None):
             if isinstance(item, tuple):
                 self.updated_problem, self.results = item
                 self.go_event.clear()
@@ -87,8 +102,9 @@ class RATRunner(QtCore.QObject):
                 self.error = item
                 self.go_event.clear()
                 self.stopped.emit()
+            elif isinstance(item, list):
+                return item[0]
             else:  # else, assume item is an event
-                print(f"{item=}")
                 self.events.append(item)
                 self.event_received.emit()
 
@@ -100,10 +116,8 @@ class RATRunner(QtCore.QObject):
                 args=(
                     self.queue,
                     self.arg_queue,
-                    self.matlab_helper.ready_event,
-                    self.matlab_helper.engine_output,
                     self.processes_list_go_exit_events[ind][0],
-                    self.processes_list_go_exit_events[ind][1]
+                    self.processes_list_go_exit_events[ind][1],
                 ),
             )
             for ind in range(self.num_cores)
@@ -122,31 +136,25 @@ class RATRunner(QtCore.QObject):
                 process.start()
 
     def stop_processes(self):
-        print("stopping processes")
-        self.clear_queues()
         self.exit_event.set()
         self.go_event.set()
-        for process in self.processes_list:
-            print(f"{process.is_alive()}")
-            if process.is_alive():
-                process.kill()
-        self.processes_list.clear()
         for go_event, exit_event in self.processes_list_go_exit_events:
             exit_event.set()
             go_event.set()
-        self.processes_list_go_exit_events = []
-        for _ in range(self.queue.qsize()):
-            print(self.queue.get())
+        for process in self.processes_list:
+            if process.is_alive():
+                process.kill()
+        self.processes_list.clear()
         self.clear_queues()
-        # for process in self.processes_list:
-        #     print(process.name)
-        #     if process.is_alive():
-        #         process.join()
-        #         print(f"{process.is_alive()}")
-        #         process.close()
+        self.processes_list_go_exit_events.clear()
+        print(f"{self.queue=}")
+        self.queue.close()
+        self.arg_queue.close()
+        if self.engine_future is not None:
+            self.engine_future.result().exit()
 
 
-def run(queue: Queue, arg_queue: Queue, engine_ready, engine_output, go_event, exit_event):
+def run(queue: Queue, arg_queue: Queue, go_event, exit_event):
     """Run RAT and put the result into the queue.
 
     Parameters
@@ -171,25 +179,10 @@ def run(queue: Queue, arg_queue: Queue, engine_ready, engine_output, go_event, e
         queue.put(LogData(INFO, "Starting RAT"))
 
     try:
-        engine_future = None
-        if any([file["language"] == "matlab" for file in problem_definition.customFiles.files]):
-            if not engine_output and display:
-                queue.put(LogData(INFO, "Attempting to start Matlab..."))
-
-            result = get_matlab_engine(engine_ready, engine_output)
-            if display:
-                queue.put(LogData(INFO, "Got Matlab engine"))
-            if isinstance(result, Exception):
-                raise result
-            else:
-                engine_future = result
-                engine_future.result().cd(os.getcwd())
         problem_definition, output_results, bayes_results = rat.rat_core.RATMain(problem_definition, cpp_controls)
         if display:
             queue.put(LogData(INFO, "Creating RAT Results..."))
         results = rat.outputs.make_results(procedure, output_results, bayes_results)
-        if engine_future is not None:
-            engine_future.result().exit()
     except Exception as err:
         queue.put(err)
         return
@@ -199,6 +192,27 @@ def run(queue: Queue, arg_queue: Queue, engine_ready, engine_output, go_event, e
         rat.events.clear()
 
     queue.put((problem_definition, results))
+
+
+def run_matlab_init_engine(queue, engine_output, engine_ready, display_on):
+    """Get the engine future from the matlab engine and put in queue if successfully."""
+    try:
+        if not engine_output and display_on:
+            queue.put(LogData(INFO, "Attempting to start Matlab..."))
+
+        result = get_matlab_engine(engine_ready, engine_output)
+        if display_on:
+            queue.put(LogData(INFO, "Got Matlab engine"))
+        if isinstance(result, Exception):
+            raise result
+        else:
+            engine_future = result
+            engine_future.result().cd(os.getcwd())
+            queue.put([engine_future])
+
+    except Exception as err:
+        queue.put(err)
+        return
 
 
 @dataclass

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -3,12 +3,15 @@
 import os
 from dataclasses import dataclass
 from logging import INFO
-from multiprocessing import Event, Process, Queue, cpu_count
+from multiprocessing import Event, Process, Queue
 
 import ratapi as rat
 from PyQt6 import QtCore
 
 from rascal2.config import MatlabHelper, get_matlab_engine
+
+NUMBER_PROCESSES = 5
+LOOP_PROCESS = True
 
 
 class RATRunner(QtCore.QObject):
@@ -20,14 +23,14 @@ class RATRunner(QtCore.QObject):
     go_event = Event()
     processes_list_go_exit_events = []
 
-    def __init__(self, parent=None, start_runners_early: bool = True, num_cores: int = cpu_count()):
+    def __init__(self, parent=None, start_runners_early: bool = True, num_processes: int = NUMBER_PROCESSES):
         super().__init__()
         self.parent = parent
         self.timer = QtCore.QTimer()
         self.timer.setInterval(1)
         self.timer.timeout.connect(self.check_queue)
         self.matlab_helper = MatlabHelper()
-        self.num_cores = num_cores
+        self.num_processes = num_processes
         self.start_runners_early = start_runners_early
 
         # this queue handles both event data and results
@@ -54,7 +57,8 @@ class RATRunner(QtCore.QObject):
 
     def start(self):
         """Start the calculation."""
-        self.process, (self.go_event, self.exit_event) = self.get_new_process()
+        if not self.process:
+            self.process, (self.go_event, self.exit_event) = self.get_new_process()
         if self.engine_future is None:
             self.get_runner_matlab_engine()
         self.go_event.set()
@@ -83,10 +87,16 @@ class RATRunner(QtCore.QObject):
 
     def interrupt(self):
         """Interrupt the running process."""
+        print(f"{self.process=}")
         self.timer.stop()
         self.process.kill()
         self.stopped.emit()
         self.go_event.clear()
+        self.clear_process()
+
+    def clear_process(self):
+        """Clear the current process."""
+        self.process = None
 
     def check_queue(self):
         """Check for new data in the queue."""
@@ -112,7 +122,7 @@ class RATRunner(QtCore.QObject):
                 self.event_received.emit()
 
     def refresh_process_list(self):
-        self.processes_list_go_exit_events = [(Event(), Event()) for _ in range(self.num_cores)]
+        self.processes_list_go_exit_events = [(Event(), Event()) for _ in range(self.num_processes)]
         self.processes_list = [
             Process(
                 target=run,
@@ -123,7 +133,7 @@ class RATRunner(QtCore.QObject):
                     self.processes_list_go_exit_events[ind][1],
                 ),
             )
-            for ind in range(self.num_cores)
+            for ind in range(self.num_processes)
         ]
 
     def clear_queues(self):
@@ -147,6 +157,7 @@ class RATRunner(QtCore.QObject):
         for process in self.processes_list:
             if process.is_alive():
                 process.kill()
+        self.process = None
         self.processes_list.clear()
         self.clear_queues()
         self.processes_list_go_exit_events.clear()
@@ -168,34 +179,37 @@ def run(queue: Queue, arg_queue: Queue, go_event, exit_event):
         A queue of arguments used to initialize the RAT process, passed from the Main Presenter
 
     """
-    go_event.wait()
-    if exit_event.is_set():
-        queue.put(LogData(INFO, "exit_event triggers"))
-        return
-    rat_inputs, procedure, display, working_dir = arg_queue.get()
-    os.chdir(working_dir)
-    problem_definition, cpp_controls = rat_inputs
+    while True:
+        go_event.wait()
+        if exit_event.is_set():
+            return
+        rat_inputs, procedure, display, working_dir = arg_queue.get()
+        os.chdir(working_dir)
+        problem_definition, cpp_controls = rat_inputs
 
-    if display:
-        rat.events.register(rat.events.EventTypes.Message, queue.put)
-        rat.events.register(rat.events.EventTypes.Progress, queue.put)
-        rat.events.register(rat.events.EventTypes.Plot, queue.put)
-        queue.put(LogData(INFO, "Starting RAT"))
-
-    try:
-        problem_definition, output_results, bayes_results = rat.rat_core.RATMain(problem_definition, cpp_controls)
         if display:
-            queue.put(LogData(INFO, "Creating RAT Results..."))
-        results = rat.outputs.make_results(procedure, output_results, bayes_results)
-    except Exception as err:
-        queue.put(err)
-        return
+            rat.events.register(rat.events.EventTypes.Message, queue.put)
+            rat.events.register(rat.events.EventTypes.Progress, queue.put)
+            rat.events.register(rat.events.EventTypes.Plot, queue.put)
+            queue.put(LogData(INFO, "Starting RAT"))
 
-    if display:
-        queue.put(LogData(INFO, "Finished RAT"))
-        rat.events.clear()
+        try:
+            problem_definition, output_results, bayes_results = rat.rat_core.RATMain(problem_definition, cpp_controls)
+            if display:
+                queue.put(LogData(INFO, "Creating RAT Results..."))
+            results = rat.outputs.make_results(procedure, output_results, bayes_results)
+        except Exception as err:
+            queue.put(err)
+            return
 
-    queue.put((problem_definition, results))
+        if display:
+            queue.put(LogData(INFO, "Finished RAT"))
+            rat.events.clear()
+
+        queue.put((problem_definition, results))
+        go_event.clear()
+        if not LOOP_PROCESS:
+            break
 
 
 def run_matlab_init_engine(queue, engine_output, engine_ready, display_on):

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -7,7 +7,6 @@ from multiprocessing import Process, Queue
 
 import ratapi as rat
 from PyQt6 import QtCore
-from ratapi.utils.enums import Procedures
 
 from rascal2.config import MatlabHelper, get_matlab_engine
 
@@ -19,33 +18,33 @@ class RATRunner(QtCore.QObject):
     finished = QtCore.pyqtSignal()
     stopped = QtCore.pyqtSignal()
 
-    def __init__(self, rat_inputs, procedure: Procedures, display_on: bool):
+    def __init__(self):
         super().__init__()
         self.timer = QtCore.QTimer()
         self.timer.setInterval(1)
         self.timer.timeout.connect(self.check_queue)
+        self.matlab_helper = MatlabHelper()
 
         # this queue handles both event data and results
         self.queue = Queue()
-        matlab_helper = MatlabHelper()
-        self.process = Process(
-            target=run,
-            args=(
-                self.queue,
-                rat_inputs,
-                procedure,
-                display_on,
-                matlab_helper.ready_event,
-                matlab_helper.engine_output,
-            ),
-        )
+        self.arg_queue = Queue()
+        self.rat_inputs = None
+        self.procedure = None
+        self.display_on = None
+        self.refresh_process_list()
         self.updated_problem = None
         self.results = None
         self.error = None
         self.events = []
 
+    def set_runner_args(self, rat_inputs, procedure, display_on: bool):
+        self.arg_queue.put((rat_inputs, procedure, display_on))
+
     def start(self):
         """Start the calculation."""
+        if not self.processes_list:
+            self.refresh_process_list()
+        self.process = self.processes_list.pop(0)
         self.process.start()
         self.timer.start()
 
@@ -71,8 +70,21 @@ class RATRunner(QtCore.QObject):
                 self.events.append(item)
                 self.event_received.emit()
 
+    def refresh_process_list(self):
+        self.processes_list = [Process(target=run, args=(
+            self.queue,
+            self.arg_queue,
+            self.matlab_helper.ready_event,
+            self.matlab_helper.engine_output,
+        )) for _ in range(5)]
 
-def run(queue, rat_inputs: tuple, procedure: str, display: bool, engine_ready, engine_output):
+    def clear_queues(self):
+        self.queue.empty()
+        self.arg_queue.empty()
+        self.events.clear()
+
+
+def run(queue, arg_queue, engine_ready, engine_output):
     """Run RAT and put the result into the queue.
 
     Parameters
@@ -87,6 +99,8 @@ def run(queue, rat_inputs: tuple, procedure: str, display: bool, engine_ready, e
         Whether to display events.
 
     """
+    rat_inputs, procedure, display = arg_queue.get()
+
     problem_definition, cpp_controls = rat_inputs
 
     if display:

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -47,8 +47,8 @@ class RATRunner(QtCore.QObject):
         self.events = []
         self.engine_future = None
 
-    def set_runner_args(self, rat_inputs, procedure, display_on: bool):
-        self.arg_queue.put((rat_inputs, procedure, display_on))
+    def set_runner_args(self, rat_inputs, procedure, display_on: bool, working_dir: str):
+        self.arg_queue.put((rat_inputs, procedure, display_on, working_dir))
         self.rat_inputs = rat_inputs
         self.display_on = display_on
 
@@ -172,7 +172,8 @@ def run(queue: Queue, arg_queue: Queue, go_event, exit_event):
     if exit_event.is_set():
         queue.put(LogData(INFO, "exit_event triggers"))
         return
-    rat_inputs, procedure, display = arg_queue.get()
+    rat_inputs, procedure, display, working_dir = arg_queue.get()
+    os.chdir(working_dir)
     problem_definition, cpp_controls = rat_inputs
 
     if display:

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -87,7 +87,6 @@ class RATRunner(QtCore.QObject):
 
     def interrupt(self):
         """Interrupt the running process."""
-        print(f"{self.process=}")
         self.timer.stop()
         self.process.kill()
         self.stopped.emit()

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -18,8 +18,10 @@ class RATRunner(QtCore.QObject):
     event_received = QtCore.pyqtSignal()
     finished = QtCore.pyqtSignal()
     stopped = QtCore.pyqtSignal()
+    go_event = Event()
+    processes_list_go_exit_events = []
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, start_runners_early: bool = True):
         super().__init__()
         self.parent = parent
         self.timer = QtCore.QTimer()
@@ -27,19 +29,20 @@ class RATRunner(QtCore.QObject):
         self.timer.timeout.connect(self.check_queue)
         self.matlab_helper = MatlabHelper()
         self.num_cores = cpu_count()
+        self.start_runners_early = start_runners_early
 
         # this queue handles both event data and results
         self.queue = Queue()
         self.arg_queue = Queue()
         self.go_event = Event()
         self.exit_event = Event()
-        self.processes_list_go_exit_events = [(Event(), Event()) for _ in range(self.num_cores)]
+        # self.processes_list_go_exit_events = [(Event(), Event()) for _ in range(self.num_cores)]
         self.rat_inputs = None
         self.procedure = None
         self.display_on = None
         self.processes_list = []
         self.refresh_process_list()
-        self.process = self.processes_list.pop(0)
+        self.process = None
         self.updated_problem = None
         self.results = None
         self.error = None
@@ -49,17 +52,19 @@ class RATRunner(QtCore.QObject):
         self.arg_queue.put((rat_inputs, procedure, display_on))
 
     def start(self):
+        print("========= START =================")
         """Start the calculation."""
-        if not self.process.is_alive():
-            if not self.processes_list:
-                self.refresh_process_list()
-            self.process = self.processes_list.pop(0)
-            # self.process.start()
-            # if self.parent:
-            #     self.parent.view.terminal_widget.write("Starting RAT Runner process...")
-            self.go_event, self.exit_event = self.processes_list_go_exit_events.pop(0)
-            self.go_event.set()
-            self.timer.start()
+        self.process, (self.go_event, self.exit_event) = self.get_new_process()
+        print(self.process)
+        print(self.go_event)
+        print(self.exit_event)
+        self.go_event.set()
+        self.timer.start()
+
+    def get_new_process(self):
+        if not self.processes_list:
+            self.refresh_process_list()
+        return self.processes_list.pop(0), self.processes_list_go_exit_events.pop(0)
 
     def interrupt(self):
         """Interrupt the running process."""
@@ -88,7 +93,7 @@ class RATRunner(QtCore.QObject):
                 self.event_received.emit()
 
     def refresh_process_list(self):
-
+        self.processes_list_go_exit_events = [(Event(), Event()) for _ in range(self.num_cores)]
         self.processes_list = [
             Process(
                 target=run,
@@ -112,26 +117,33 @@ class RATRunner(QtCore.QObject):
         self.exit_event.clear()
 
     def start_processes(self):
-        for process in self.processes_list:
-            process.start()
+        if self.start_runners_early:
+            for process in self.processes_list:
+                process.start()
 
     def stop_processes(self):
         print("stopping processes")
+        self.clear_queues()
         self.exit_event.set()
         self.go_event.set()
         for process in self.processes_list:
             print(f"{process.is_alive()}")
+            if process.is_alive():
+                process.kill()
+        self.processes_list.clear()
         for go_event, exit_event in self.processes_list_go_exit_events:
             exit_event.set()
             go_event.set()
+        self.processes_list_go_exit_events = []
         for _ in range(self.queue.qsize()):
             print(self.queue.get())
         self.clear_queues()
-        for process in self.processes_list:
-            print(process.name)
-            process.join()
-            print(f"{process.is_alive()}")
-            process.close()
+        # for process in self.processes_list:
+        #     print(process.name)
+        #     if process.is_alive():
+        #         process.join()
+        #         print(f"{process.is_alive()}")
+        #         process.close()
 
 
 def run(queue: Queue, arg_queue: Queue, engine_ready, engine_output, go_event, exit_event):

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -58,6 +58,8 @@ class RATRunner(QtCore.QObject):
         if self.engine_future is None:
             self.get_runner_matlab_engine()
         self.go_event.set()
+        if not self.process.is_alive():
+            self.process.start()
         self.timer.start()
 
     def get_new_process(self):
@@ -76,6 +78,7 @@ class RATRunner(QtCore.QObject):
                 args=(matlab_queue, engine_output, engine_ready, self.display_on),
             )
             get_runner_matlab_engine_process.start()
+            get_runner_matlab_engine_process.join()
             self.engine_future = self.filter_queue(matlab_queue)
 
     def interrupt(self):
@@ -147,11 +150,11 @@ class RATRunner(QtCore.QObject):
         self.processes_list.clear()
         self.clear_queues()
         self.processes_list_go_exit_events.clear()
-        print(f"{self.queue=}")
         self.queue.close()
         self.arg_queue.close()
         if self.engine_future is not None:
             self.engine_future.result().exit()
+        self.matlab_helper.close_event.set()
 
 
 def run(queue: Queue, arg_queue: Queue, go_event, exit_event):

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -18,8 +18,9 @@ class RATRunner(QtCore.QObject):
     finished = QtCore.pyqtSignal()
     stopped = QtCore.pyqtSignal()
 
-    def __init__(self):
+    def __init__(self, parent=None):
         super().__init__()
+        self.parent = parent
         self.timer = QtCore.QTimer()
         self.timer.setInterval(1)
         self.timer.timeout.connect(self.check_queue)
@@ -31,7 +32,9 @@ class RATRunner(QtCore.QObject):
         self.rat_inputs = None
         self.procedure = None
         self.display_on = None
+        self.processes_list = []
         self.refresh_process_list()
+        self.process = self.processes_list.pop(0)
         self.updated_problem = None
         self.results = None
         self.error = None
@@ -46,6 +49,8 @@ class RATRunner(QtCore.QObject):
             self.refresh_process_list()
         self.process = self.processes_list.pop(0)
         self.process.start()
+        if self.parent:
+            self.parent.view.terminal_widget.write("Starting RAT Runner process...")
         self.timer.start()
 
     def interrupt(self):
@@ -71,12 +76,18 @@ class RATRunner(QtCore.QObject):
                 self.event_received.emit()
 
     def refresh_process_list(self):
-        self.processes_list = [Process(target=run, args=(
-            self.queue,
-            self.arg_queue,
-            self.matlab_helper.ready_event,
-            self.matlab_helper.engine_output,
-        )) for _ in range(5)]
+        self.processes_list = [
+            Process(
+                target=run,
+                args=(
+                    self.queue,
+                    self.arg_queue,
+                    self.matlab_helper.ready_event,
+                    self.matlab_helper.engine_output,
+                ),
+            )
+            for _ in range(5)
+        ]
 
     def clear_queues(self):
         self.queue.empty()
@@ -91,16 +102,11 @@ def run(queue, arg_queue, engine_ready, engine_output):
     ----------
     queue : Queue
         The interprocess queue for the RATRunner.
-    rat_inputs : tuple
-        The C++ inputs for rat.
-    procedure : str
-        The optimisation procedure.
-    display : bool
-        Whether to display events.
+    arg_queue :
+        A queue of arguments used to initialize the RAT process, passed from the Main Presenter
 
     """
     rat_inputs, procedure, display = arg_queue.get()
-
     problem_definition, cpp_controls = rat_inputs
 
     if display:
@@ -112,17 +118,20 @@ def run(queue, arg_queue, engine_ready, engine_output):
     try:
         engine_future = None
         if any([file["language"] == "matlab" for file in problem_definition.customFiles.files]):
-            if not engine_output:
+            if not engine_output and display:
                 queue.put(LogData(INFO, "Attempting to start Matlab..."))
 
             result = get_matlab_engine(engine_ready, engine_output)
+            if display:
+                queue.put(LogData(INFO, "Got Matlab engine"))
             if isinstance(result, Exception):
                 raise result
             else:
                 engine_future = result
                 engine_future.result().cd(os.getcwd())
-
         problem_definition, output_results, bayes_results = rat.rat_core.RATMain(problem_definition, cpp_controls)
+        if display:
+            queue.put(LogData(INFO, "Creating RAT Results..."))
         results = rat.outputs.make_results(procedure, output_results, bayes_results)
         if engine_future is not None:
             engine_future.result().exit()

--- a/rascal2/core/runner.py
+++ b/rascal2/core/runner.py
@@ -1,9 +1,10 @@
 """QObject for running rat."""
 
 import os
+import time
 from dataclasses import dataclass
 from logging import INFO
-from multiprocessing import Process, Queue
+from multiprocessing import Process, Queue, cpu_count, Event
 
 import ratapi as rat
 from PyQt6 import QtCore
@@ -25,10 +26,14 @@ class RATRunner(QtCore.QObject):
         self.timer.setInterval(1)
         self.timer.timeout.connect(self.check_queue)
         self.matlab_helper = MatlabHelper()
+        self.num_cores = cpu_count()
 
         # this queue handles both event data and results
         self.queue = Queue()
         self.arg_queue = Queue()
+        self.go_event = Event()
+        self.exit_event = Event()
+        self.processes_list_go_exit_events = [(Event(), Event()) for _ in range(self.num_cores)]
         self.rat_inputs = None
         self.procedure = None
         self.display_on = None
@@ -45,19 +50,23 @@ class RATRunner(QtCore.QObject):
 
     def start(self):
         """Start the calculation."""
-        if not self.processes_list:
-            self.refresh_process_list()
-        self.process = self.processes_list.pop(0)
-        self.process.start()
-        if self.parent:
-            self.parent.view.terminal_widget.write("Starting RAT Runner process...")
-        self.timer.start()
+        if not self.process.is_alive():
+            if not self.processes_list:
+                self.refresh_process_list()
+            self.process = self.processes_list.pop(0)
+            # self.process.start()
+            # if self.parent:
+            #     self.parent.view.terminal_widget.write("Starting RAT Runner process...")
+            self.go_event, self.exit_event = self.processes_list_go_exit_events.pop(0)
+            self.go_event.set()
+            self.timer.start()
 
     def interrupt(self):
         """Interrupt the running process."""
         self.timer.stop()
         self.process.kill()
         self.stopped.emit()
+        self.go_event.clear()
 
     def check_queue(self):
         """Check for new data in the queue."""
@@ -67,15 +76,19 @@ class RATRunner(QtCore.QObject):
         for item in iter(self.queue.get, None):
             if isinstance(item, tuple):
                 self.updated_problem, self.results = item
+                self.go_event.clear()
                 self.finished.emit()
             elif isinstance(item, Exception):
                 self.error = item
+                self.go_event.clear()
                 self.stopped.emit()
             else:  # else, assume item is an event
+                print(f"{item=}")
                 self.events.append(item)
                 self.event_received.emit()
 
     def refresh_process_list(self):
+
         self.processes_list = [
             Process(
                 target=run,
@@ -84,18 +97,44 @@ class RATRunner(QtCore.QObject):
                     self.arg_queue,
                     self.matlab_helper.ready_event,
                     self.matlab_helper.engine_output,
+                    self.processes_list_go_exit_events[ind][0],
+                    self.processes_list_go_exit_events[ind][1]
                 ),
             )
-            for _ in range(5)
+            for ind in range(self.num_cores)
         ]
 
     def clear_queues(self):
         self.queue.empty()
         self.arg_queue.empty()
         self.events.clear()
+        self.go_event.clear()
+        self.exit_event.clear()
+
+    def start_processes(self):
+        for process in self.processes_list:
+            process.start()
+
+    def stop_processes(self):
+        print("stopping processes")
+        self.exit_event.set()
+        self.go_event.set()
+        for process in self.processes_list:
+            print(f"{process.is_alive()}")
+        for go_event, exit_event in self.processes_list_go_exit_events:
+            exit_event.set()
+            go_event.set()
+        for _ in range(self.queue.qsize()):
+            print(self.queue.get())
+        self.clear_queues()
+        for process in self.processes_list:
+            print(process.name)
+            process.join()
+            print(f"{process.is_alive()}")
+            process.close()
 
 
-def run(queue, arg_queue, engine_ready, engine_output):
+def run(queue: Queue, arg_queue: Queue, engine_ready, engine_output, go_event, exit_event):
     """Run RAT and put the result into the queue.
 
     Parameters
@@ -106,6 +145,10 @@ def run(queue, arg_queue, engine_ready, engine_output):
         A queue of arguments used to initialize the RAT process, passed from the Main Presenter
 
     """
+    go_event.wait()
+    if exit_event.is_set():
+        queue.put(LogData(INFO, "exit_event triggers"))
+        return
     rat_inputs, procedure, display = arg_queue.get()
     problem_definition, cpp_controls = rat_inputs
 

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -1,11 +1,11 @@
 import os
 import re
-import time
 import warnings
 from typing import Any
 
 import ratapi as rat
 import ratapi.wrappers
+from PyQt6.QtCore import QCoreApplication
 
 from rascal2.config import LOGGER, SETTINGS, MatlabHelper
 from rascal2.core import commands
@@ -30,11 +30,10 @@ class MainWindowPresenter:
         self.view = view
         self.model = MainWindowModel()
         self.worker = None
-        self.runner = RATRunner()
+        self.runner = RATRunner(self)
         self.runner.finished.connect(self.handle_results)
         self.runner.stopped.connect(self.handle_interrupt)
         self.runner.event_received.connect(self.handle_event)
-
 
     def create_project(self, name: str, save_path: str):
         """Create a new RAT project and controls object then initialise UI.
@@ -225,7 +224,6 @@ class MainWindowPresenter:
     def run(self):
         """Run rat using multiprocessing."""
         # reset terminal
-        self.t1 = time.perf_counter()
         self.view.terminal_widget.progress_bar.setVisible(False)
         if SETTINGS.clear_terminal:
             self.view.terminal_widget.clear()
@@ -236,11 +234,8 @@ class MainWindowPresenter:
         self.model.controls.initialise_IPC()
         rat_inputs = rat.inputs.make_input(self.model.project, self.model.controls)
         display_on = self.model.controls.display != rat.utils.enums.Display.Off
-
         self.runner.set_runner_args(rat_inputs, self.model.controls.procedure, display_on)
-
         self.view.terminal_widget.write("Initializing RAT Process...")
-        self.t2 = time.perf_counter()
         self.runner.start()
 
     def handle_results(self):
@@ -256,9 +251,6 @@ class MainWindowPresenter:
         self.view.handle_results(self.runner.results)
         self.model.controls.delete_IPC()
         self.runner.clear_queues()
-        self.t3 = time.perf_counter()
-        print(f"{(self.t2 - self.t1)=}")
-        print(f"{(self.t3 - self.t1)=}")
 
     def handle_interrupt(self):
         """Handle a RAT run being interrupted."""
@@ -271,20 +263,20 @@ class MainWindowPresenter:
 
     def handle_event(self):
         """Handle event data produced by the RAT run."""
-        if self.runner.events:
-            event = self.runner.events.pop(0)
-            match event:
-                case str():
-                    self.view.terminal_widget.write(event)
-                    chi_squared = get_live_chi_squared(event, str(self.model.controls.procedure))
-                    if chi_squared is not None:
-                        self.view.controls_widget.chi_squared.setText(chi_squared)
-                case rat.events.ProgressEventData():
-                    self.view.terminal_widget.update_progress(event)
-                case rat.events.PlotEventData():
-                    self.view.plot_widget.plot_with_blit(event)
-                case LogData():
-                    LOGGER.log(event.level, event.msg)
+        event = self.runner.events.pop(0)
+        match event:
+            case str():
+                self.view.terminal_widget.write(event)
+                chi_squared = get_live_chi_squared(event, str(self.model.controls.procedure))
+                if chi_squared is not None:
+                    self.view.controls_widget.update_chi_squared(chi_squared)
+            case rat.events.ProgressEventData():
+                self.view.terminal_widget.update_progress(event)
+            case rat.events.PlotEventData():
+                self.view.plot_widget.plot_with_blit(event)
+            case LogData():
+                LOGGER.log(event.level, event.msg)
+        QCoreApplication.processEvents()
 
     def edit_project(self, updated_project: dict, preview: bool = True) -> None:
         """Edit the Project with a dictionary of attributes.

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -1,6 +1,5 @@
 import os
 import re
-import time
 import warnings
 from typing import Any
 
@@ -17,6 +16,8 @@ from rascal2.settings import update_recent_projects
 
 from .model import MainWindowModel
 
+START_PROCESSES = bool(os.getenv("START_PROCESSES", "True"))
+
 
 class MainWindowPresenter:
     """Facilitates interaction between View and Model.
@@ -31,7 +32,7 @@ class MainWindowPresenter:
         self.view = view
         self.model = MainWindowModel()
         self.worker = None
-        self.runner = RATRunner(self)
+        self.runner = RATRunner(self, start_runners_early=START_PROCESSES)
         self.runner.finished.connect(self.handle_results)
         self.runner.stopped.connect(self.handle_interrupt)
         self.runner.event_received.connect(self.handle_event)

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 import warnings
 from typing import Any
 
@@ -34,6 +35,7 @@ class MainWindowPresenter:
         self.runner.finished.connect(self.handle_results)
         self.runner.stopped.connect(self.handle_interrupt)
         self.runner.event_received.connect(self.handle_event)
+        self.runner.start_processes()
 
     def create_project(self, name: str, save_path: str):
         """Create a new RAT project and controls object then initialise UI.
@@ -224,6 +226,7 @@ class MainWindowPresenter:
     def run(self):
         """Run rat using multiprocessing."""
         # reset terminal
+        self.t1 = time.perf_counter()
         self.view.terminal_widget.progress_bar.setVisible(False)
         if SETTINGS.clear_terminal:
             self.view.terminal_widget.clear()
@@ -251,6 +254,7 @@ class MainWindowPresenter:
         self.view.handle_results(self.runner.results)
         self.model.controls.delete_IPC()
         self.runner.clear_queues()
+        print(f"{time.perf_counter() - self.t1} seconds elapsed.")
 
     def handle_interrupt(self):
         """Handle a RAT run being interrupted."""

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -226,7 +226,6 @@ class MainWindowPresenter:
     def run(self):
         """Run rat using multiprocessing."""
         # reset terminal
-        self.t1 = time.perf_counter()
         self.view.terminal_widget.progress_bar.setVisible(False)
         if SETTINGS.clear_terminal:
             self.view.terminal_widget.clear()
@@ -254,7 +253,6 @@ class MainWindowPresenter:
         self.view.handle_results(self.runner.results)
         self.model.controls.delete_IPC()
         self.runner.clear_queues()
-        print(f"{time.perf_counter() - self.t1} seconds elapsed.")
 
     def handle_interrupt(self):
         """Handle a RAT run being interrupted."""

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -1,7 +1,6 @@
 import os
 import re
 import warnings
-from multiprocessing import Queue
 from typing import Any
 
 import ratapi as rat
@@ -242,6 +241,7 @@ class MainWindowPresenter:
         self.runner.set_runner_args(rat_inputs, self.model.controls.procedure, display_on, working_dir)
         self.view.terminal_widget.write("Initializing RAT Process...")
         self.runner.start()
+        print(self.runner.process.name)
 
     def handle_results(self):
         """Handle a RAT run being finished."""

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -1,6 +1,7 @@
 import os
 import re
 import warnings
+from multiprocessing import Queue
 from typing import Any
 
 import ratapi as rat
@@ -235,9 +236,10 @@ class MainWindowPresenter:
         self.view.plot_widget.bayes_plots_button.setVisible(False)
 
         self.model.controls.initialise_IPC()
+        working_dir = os.getcwd()
         rat_inputs = rat.inputs.make_input(self.model.project, self.model.controls)
         display_on = self.model.controls.display != rat.utils.enums.Display.Off
-        self.runner.set_runner_args(rat_inputs, self.model.controls.procedure, display_on)
+        self.runner.set_runner_args(rat_inputs, self.model.controls.procedure, display_on, working_dir)
         self.view.terminal_widget.write("Initializing RAT Process...")
         self.runner.start()
 

--- a/rascal2/ui/presenter.py
+++ b/rascal2/ui/presenter.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 import warnings
 from typing import Any
 
@@ -29,6 +30,11 @@ class MainWindowPresenter:
         self.view = view
         self.model = MainWindowModel()
         self.worker = None
+        self.runner = RATRunner()
+        self.runner.finished.connect(self.handle_results)
+        self.runner.stopped.connect(self.handle_interrupt)
+        self.runner.event_received.connect(self.handle_event)
+
 
     def create_project(self, name: str, save_path: str):
         """Create a new RAT project and controls object then initialise UI.
@@ -219,6 +225,7 @@ class MainWindowPresenter:
     def run(self):
         """Run rat using multiprocessing."""
         # reset terminal
+        self.t1 = time.perf_counter()
         self.view.terminal_widget.progress_bar.setVisible(False)
         if SETTINGS.clear_terminal:
             self.view.terminal_widget.clear()
@@ -230,11 +237,10 @@ class MainWindowPresenter:
         rat_inputs = rat.inputs.make_input(self.model.project, self.model.controls)
         display_on = self.model.controls.display != rat.utils.enums.Display.Off
 
-        self.runner = RATRunner(rat_inputs, self.model.controls.procedure, display_on)
-        self.runner.finished.connect(self.handle_results)
-        self.runner.stopped.connect(self.handle_interrupt)
-        self.runner.event_received.connect(self.handle_event)
+        self.runner.set_runner_args(rat_inputs, self.model.controls.procedure, display_on)
+
         self.view.terminal_widget.write("Initializing RAT Process...")
+        self.t2 = time.perf_counter()
         self.runner.start()
 
     def handle_results(self):
@@ -249,6 +255,10 @@ class MainWindowPresenter:
         )
         self.view.handle_results(self.runner.results)
         self.model.controls.delete_IPC()
+        self.runner.clear_queues()
+        self.t3 = time.perf_counter()
+        print(f"{(self.t2 - self.t1)=}")
+        print(f"{(self.t3 - self.t1)=}")
 
     def handle_interrupt(self):
         """Handle a RAT run being interrupted."""
@@ -261,19 +271,20 @@ class MainWindowPresenter:
 
     def handle_event(self):
         """Handle event data produced by the RAT run."""
-        event = self.runner.events.pop(0)
-        match event:
-            case str():
-                self.view.terminal_widget.write(event)
-                chi_squared = get_live_chi_squared(event, str(self.model.controls.procedure))
-                if chi_squared is not None:
-                    self.view.controls_widget.update_chi_squared(chi_squared)
-            case rat.events.ProgressEventData():
-                self.view.terminal_widget.update_progress(event)
-            case rat.events.PlotEventData():
-                self.view.plot_widget.plot_with_blit(event)
-            case LogData():
-                LOGGER.log(event.level, event.msg)
+        if self.runner.events:
+            event = self.runner.events.pop(0)
+            match event:
+                case str():
+                    self.view.terminal_widget.write(event)
+                    chi_squared = get_live_chi_squared(event, str(self.model.controls.procedure))
+                    if chi_squared is not None:
+                        self.view.controls_widget.chi_squared.setText(chi_squared)
+                case rat.events.ProgressEventData():
+                    self.view.terminal_widget.update_progress(event)
+                case rat.events.PlotEventData():
+                    self.view.plot_widget.plot_with_blit(event)
+                case LogData():
+                    LOGGER.log(event.level, event.msg)
 
     def edit_project(self, updated_project: dict, preview: bool = True) -> None:
         """Edit the Project with a dictionary of attributes.

--- a/rascal2/ui/view.py
+++ b/rascal2/ui/view.py
@@ -81,6 +81,8 @@ class MainWindowView(QtWidgets.QMainWindow):
             event.accept()
         else:
             event.ignore()
+        self.presenter.runner.stop_processes()
+        event.accept()
 
     def show_project_dialog(self, dialog: StartupDialog):
         """Show a startup dialog of a given type.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,18 @@ def global_setting():
     return GLOBAL_SETTING
 
 
+@pytest.fixture(autouse=True)
+@patch("rascal2.core.runner.cpu_count")
+def fix_cpu_count(cpu_count):
+    cpu_count.return_value = 1
+    yield
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_start_processes_setting(monkeypatch):
+    monkeypatch.setenv("START_PROCESSES", "False")
+
+
 @pytest.fixture(scope="session", autouse=True)
 def mock_setting(request):
     global GLOBAL_SETTING

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,9 @@ def global_setting():
 
 
 @pytest.fixture(autouse=True)
-@patch("rascal2.core.runner.cpu_count")
-def fix_cpu_count(cpu_count):
-    cpu_count.return_value = 1
+@patch("rascal2.core.runner.NUMBER_PROCESSES")
+def fix_num_processes(num_processes):
+    num_processes.return_value = 1
     yield
 
 

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -36,7 +36,8 @@ def mock_rat_main(*args, **kwargs):
 
 def close_processes(runner):
     # Non serialised queue does not have a close attribute so have to mock it out
-    runner.process.join()
+    if runner.process is not None:
+        runner.process.join()
     runner.queue.close = MagicMock()
     runner.arg_queue.close = MagicMock()
     runner.stop_processes()
@@ -245,4 +246,28 @@ def test_start_reuses_process(mock_process_go_exit, mock_process, mock_matlab):
     runner.get_new_process.assert_called_once()
     runner.start()
     runner.get_new_process.assert_called_once()
+    close_processes(runner)
+
+
+@patch("rascal2.core.runner.MatlabHelper", autospec=True)
+@patch("rascal2.core.runner.Process")
+@patch("rascal2.core.runner.RATRunner.get_new_process")
+def test_interrupt_creates_new_process(mock_process_go_exit, mock_process, mock_matlab):
+    """Test that when interrupting a process, it will use a new process on next run."""
+    mock_matlab.return_value = MagicMock()
+    mock_go = MagicMock()
+    mock_process_go_exit.return_value = MagicMock(), (mock_go, MagicMock())
+    runner = RATRunner(start_runners_early=False, num_processes=1)
+    runner.process = None
+    runner.get_runner_matlab_engine = MagicMock()
+    runner.get_new_process = MagicMock(return_value=(MagicMock(), (MagicMock(), MagicMock())))
+    runner.set_runner_args(make_rat_input(), "", True, os.getcwd())
+    runner.start()
+    runner.get_new_process.assert_called_once()
+    assert runner.process is not None
+    runner.interrupt()
+    assert runner.process is None
+    runner.start()
+    assert runner.process is not None
+    assert runner.get_new_process.call_count == 2
     close_processes(runner)

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -38,7 +38,8 @@ def mock_rat_main(*args, **kwargs):
 def test_start(mock_process, mock_matlab):
     """Test that `start` creates and starts a process and timer."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner(make_rat_input(), "", True)
+    runner = RATRunner()
+    runner.set_runner_args(make_rat_input(), "", True)
     runner.start()
 
     runner.process.start.assert_called_once()
@@ -50,7 +51,8 @@ def test_start(mock_process, mock_matlab):
 def test_interrupt(mock_process, mock_matlab):
     """Test that `interrupt` kills the process and stops the timer."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner([], "", True)
+    runner = RATRunner()
+    runner.set_runner_args([], "", True)
     runner.interrupt()
 
     runner.process.kill.assert_called_once()
@@ -73,7 +75,8 @@ def test_interrupt(mock_process, mock_matlab):
 def test_check_queue(mock_process, mock_matlab, queue_items):
     """Test that queue data is appropriately assigned."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner([], "", True)
+    runner = RATRunner()
+    runner.set_runner_args([], "", True)
     runner.queue = Queue()
 
     for item in queue_items:
@@ -101,7 +104,8 @@ def test_check_queue(mock_process, mock_matlab, queue_items):
 def test_empty_queue(mock_process, mock_matlab):
     """Test that nothing happens if the queue is empty."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner(make_rat_input(), "", True)
+    runner = RATRunner()
+    runner.set_runner_args(make_rat_input(), "", True)
     runner.check_queue()
 
     assert len(runner.events) == 0
@@ -114,7 +118,9 @@ def test_empty_queue(mock_process, mock_matlab):
 def test_run(display):
     """Test that a run puts the correct items in the queue."""
     queue = Queue()
-    run(queue, make_rat_input(), "", display, None, None)
+    arg_queue = Queue()
+    arg_queue.put((make_rat_input(), "", display))
+    run(queue, arg_queue, None, None)
     expected_display = [
         LogData(20, "Starting RAT"),
         0.2,
@@ -122,6 +128,7 @@ def test_run(display):
         "test message",
         "test message 2",
         0.7,
+        LogData(20, "Creating RAT Results..."),
         LogData(20, "Finished RAT"),
     ]
 
@@ -147,7 +154,9 @@ def test_run_error():
 
     queue = Queue()
     with patch("ratapi.rat_core.RATMain", new=erroring_ratmain):
-        run(queue, make_rat_input(), "", True, None, None)
+        args_queue = Queue()
+        args_queue.put((make_rat_input(), "", True))
+        run(queue, args_queue, None, None)
 
     queue.put(None)
     queue_contents = list(iter(queue.get, None))
@@ -172,7 +181,9 @@ def test_run_examples(example):
     rat_inputs = rat.inputs.make_input(project, rat.Controls())
 
     queue = Queue()
-    run(queue, rat_inputs, "calculate", False, None, None)
+    args_queue = Queue()
+    args_queue.put((rat_inputs, "calculate", False))
+    run(queue, args_queue, None, None)
 
     output = queue.get()
 

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import os
+from multiprocessing import Event
 from queue import Queue  # we need a non-multiprocessing queue because mocks cannot be serialised
 from unittest.mock import MagicMock, patch
 
@@ -35,15 +36,22 @@ def mock_rat_main(*args, **kwargs):
 
 @patch("rascal2.core.runner.MatlabHelper", autospec=True)
 @patch("rascal2.core.runner.Process")
-def test_start(mock_process, mock_matlab):
+@patch("rascal2.core.runner.RATRunner.get_new_process")
+def test_start(mock_process_go_exit, mock_process, mock_matlab):
     """Test that `start` creates and starts a process and timer."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner()
+    mock_go = MagicMock()
+    mock_process_go_exit.return_value = MagicMock(), (mock_go, MagicMock())
+    runner = RATRunner(start_runners_early=False)
+    runner.process = MagicMock()
+    runner.num_cores = MagicMock(return_value=1)
     runner.set_runner_args(make_rat_input(), "", True)
     runner.start()
 
-    runner.process.start.assert_called_once()
+    mock_go.set.assert_called_once()
     assert runner.timer.isActive()
+
+    runner.stop_processes()
 
 
 @patch("rascal2.core.runner.MatlabHelper", autospec=True)
@@ -51,12 +59,15 @@ def test_start(mock_process, mock_matlab):
 def test_interrupt(mock_process, mock_matlab):
     """Test that `interrupt` kills the process and stops the timer."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner()
+    runner = RATRunner(start_runners_early=False)
+    runner.process = MagicMock()
     runner.set_runner_args([], "", True)
     runner.interrupt()
 
     runner.process.kill.assert_called_once()
     assert not runner.timer.isActive()
+
+    runner.stop_processes()
 
 
 @pytest.mark.parametrize(
@@ -75,7 +86,8 @@ def test_interrupt(mock_process, mock_matlab):
 def test_check_queue(mock_process, mock_matlab, queue_items):
     """Test that queue data is appropriately assigned."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner()
+    runner = RATRunner(start_runners_early=False)
+    runner.process = MagicMock()
     runner.set_runner_args([], "", True)
     runner.queue = Queue()
 
@@ -98,18 +110,23 @@ def test_check_queue(mock_process, mock_matlab, queue_items):
         assert isinstance(runner.error, ValueError)
         assert str(runner.error) == "Runner error!"
 
+    runner.stop_processes()
+
 
 @patch("rascal2.core.runner.MatlabHelper", autospec=True)
 @patch("rascal2.core.runner.Process")
 def test_empty_queue(mock_process, mock_matlab):
     """Test that nothing happens if the queue is empty."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner()
+    runner = RATRunner(start_runners_early=False)
+    runner.process = MagicMock()
     runner.set_runner_args(make_rat_input(), "", True)
     runner.check_queue()
 
     assert len(runner.events) == 0
     assert runner.results is None
+
+    runner.stop_processes()
 
 
 @pytest.mark.parametrize("display", [True, False])
@@ -120,7 +137,10 @@ def test_run(display):
     queue = Queue()
     arg_queue = Queue()
     arg_queue.put((make_rat_input(), "", display))
-    run(queue, arg_queue, None, None)
+    go_event, exit_event = (Event(), Event())
+    go_event.set()
+    run(queue, arg_queue, None, None, go_event, exit_event)
+
     expected_display = [
         LogData(20, "Starting RAT"),
         0.2,
@@ -156,7 +176,9 @@ def test_run_error():
     with patch("ratapi.rat_core.RATMain", new=erroring_ratmain):
         args_queue = Queue()
         args_queue.put((make_rat_input(), "", True))
-        run(queue, args_queue, None, None)
+        go_event, exit_event = (Event(), Event())
+        go_event.set()
+        run(queue, args_queue, None, None, go_event, exit_event)
 
     queue.put(None)
     queue_contents = list(iter(queue.get, None))
@@ -183,7 +205,9 @@ def test_run_examples(example):
     queue = Queue()
     args_queue = Queue()
     args_queue.put((rat_inputs, "calculate", False))
-    run(queue, args_queue, None, None)
+    go_event, exit_event = (Event(), Event())
+    go_event.set()
+    run(queue, args_queue, None, None, go_event, exit_event)
 
     output = queue.get()
 

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -50,8 +50,8 @@ def test_start(mock_process_go_exit, mock_process, mock_matlab):
     mock_matlab.return_value = MagicMock()
     mock_go = MagicMock()
     mock_process_go_exit.return_value = MagicMock(), (mock_go, MagicMock())
-    runner = RATRunner(start_runners_early=False, num_cores=1)
-    runner.process = MagicMock()
+    runner = RATRunner(start_runners_early=False, num_processes=1)
+    runner.process = None
     runner.get_runner_matlab_engine = MagicMock()
     runner.set_runner_args(make_rat_input(), "", True, os.getcwd())
     runner.start()
@@ -67,8 +67,9 @@ def test_start(mock_process_go_exit, mock_process, mock_matlab):
 def test_interrupt(mock_process, mock_matlab):
     """Test that `interrupt` kills the process and stops the timer."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner(start_runners_early=False, num_cores=1)
+    runner = RATRunner(start_runners_early=False, num_processes=1)
     runner.process = MagicMock()
+    runner.clear_process = MagicMock()
     runner.set_runner_args([], "", True, os.getcwd())
     runner.interrupt()
 
@@ -94,7 +95,7 @@ def test_interrupt(mock_process, mock_matlab):
 def test_check_queue(mock_process, mock_matlab, queue_items):
     """Test that queue data is appropriately assigned."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner(start_runners_early=False, num_cores=1)
+    runner = RATRunner(start_runners_early=False, num_processes=1)
     runner.process = MagicMock()
     runner.get_runner_matlab_engine = MagicMock()
     runner.set_runner_args([], "", True, os.getcwd())
@@ -127,7 +128,7 @@ def test_check_queue(mock_process, mock_matlab, queue_items):
 def test_empty_queue(mock_process, mock_matlab):
     """Test that nothing happens if the queue is empty."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner(start_runners_early=False, num_cores=1)
+    runner = RATRunner(start_runners_early=False, num_processes=1)
     runner.process = MagicMock()
     runner.set_runner_args(make_rat_input(), "", True, os.getcwd())
 
@@ -142,6 +143,7 @@ def test_empty_queue(mock_process, mock_matlab):
 @pytest.mark.parametrize("display", [True, False])
 @patch("ratapi.rat_core.RATMain", new=mock_rat_main)
 @patch("ratapi.outputs.make_results", new=MagicMock(spec=rat.outputs.Results))
+@patch("rascal2.core.runner.LOOP_PROCESS", new=False)
 def test_run(display):
     """Test that a run puts the correct items in the queue."""
     queue = Queue()
@@ -200,6 +202,7 @@ def test_run_error():
 
 
 @pytest.mark.parametrize("example", rat.examples.__all__)
+@patch("rascal2.core.runner.LOOP_PROCESS", new=False)
 def test_run_examples(example):
     """Test that the run function runs without an error on the ratapi example projects."""
     # skip convert rascal example

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -226,3 +226,23 @@ def test_run_examples(example):
 
     assert isinstance(output[0], rat.rat_core.ProblemDefinition)
     assert isinstance(output[1], rat.outputs.Results)
+
+
+@patch("rascal2.core.runner.MatlabHelper", autospec=True)
+@patch("rascal2.core.runner.Process")
+@patch("rascal2.core.runner.RATRunner.get_new_process")
+def test_start_reuses_process(mock_process_go_exit, mock_process, mock_matlab):
+    """Test that when running `start` a second time, it will reuse the previous process."""
+    mock_matlab.return_value = MagicMock()
+    mock_go = MagicMock()
+    mock_process_go_exit.return_value = MagicMock(), (mock_go, MagicMock())
+    runner = RATRunner(start_runners_early=False, num_processes=1)
+    runner.process = None
+    runner.get_runner_matlab_engine = MagicMock()
+    runner.get_new_process = MagicMock(return_value=(MagicMock(), (MagicMock(), MagicMock())))
+    runner.set_runner_args(make_rat_input(), "", True, os.getcwd())
+    runner.start()
+    runner.get_new_process.assert_called_once()
+    runner.start()
+    runner.get_new_process.assert_called_once()
+    close_processes(runner)

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -36,6 +36,7 @@ def mock_rat_main(*args, **kwargs):
 
 def close_processes(runner):
     # Non serialised queue does not have a close attribute so have to mock it out
+    runner.process.join()
     runner.queue.close = MagicMock()
     runner.arg_queue.close = MagicMock()
     runner.stop_processes()
@@ -52,7 +53,7 @@ def test_start(mock_process_go_exit, mock_process, mock_matlab):
     runner = RATRunner(start_runners_early=False, num_cores=1)
     runner.process = MagicMock()
     runner.get_runner_matlab_engine = MagicMock()
-    runner.set_runner_args(make_rat_input(), "", True)
+    runner.set_runner_args(make_rat_input(), "", True, os.getcwd())
     runner.start()
 
     mock_go.set.assert_called_once()
@@ -68,7 +69,7 @@ def test_interrupt(mock_process, mock_matlab):
     mock_matlab.return_value = MagicMock()
     runner = RATRunner(start_runners_early=False, num_cores=1)
     runner.process = MagicMock()
-    runner.set_runner_args([], "", True)
+    runner.set_runner_args([], "", True, os.getcwd())
     runner.interrupt()
 
     runner.process.kill.assert_called_once()
@@ -96,7 +97,7 @@ def test_check_queue(mock_process, mock_matlab, queue_items):
     runner = RATRunner(start_runners_early=False, num_cores=1)
     runner.process = MagicMock()
     runner.get_runner_matlab_engine = MagicMock()
-    runner.set_runner_args([], "", True)
+    runner.set_runner_args([], "", True, os.getcwd())
     runner.queue = Queue()
 
     for item in queue_items:
@@ -128,7 +129,7 @@ def test_empty_queue(mock_process, mock_matlab):
     mock_matlab.return_value = MagicMock()
     runner = RATRunner(start_runners_early=False, num_cores=1)
     runner.process = MagicMock()
-    runner.set_runner_args(make_rat_input(), "", True)
+    runner.set_runner_args(make_rat_input(), "", True, os.getcwd())
 
     runner.check_queue()
 
@@ -145,7 +146,7 @@ def test_run(display):
     """Test that a run puts the correct items in the queue."""
     queue = Queue()
     arg_queue = Queue()
-    arg_queue.put((make_rat_input(), "", display))
+    arg_queue.put((make_rat_input(), "", display, os.getcwd()))
     go_event, exit_event = (Event(), Event())
     go_event.set()
     run(queue, arg_queue, go_event, exit_event)
@@ -184,7 +185,7 @@ def test_run_error():
     queue = Queue()
     with patch("ratapi.rat_core.RATMain", new=erroring_ratmain):
         args_queue = Queue()
-        args_queue.put((make_rat_input(), "", True))
+        args_queue.put((make_rat_input(), "", True, os.getcwd()))
         go_event, exit_event = (Event(), Event())
         go_event.set()
         run(queue, args_queue, go_event, exit_event)
@@ -213,7 +214,7 @@ def test_run_examples(example):
 
     queue = Queue()
     args_queue = Queue()
-    args_queue.put((rat_inputs, "calculate", False))
+    args_queue.put((rat_inputs, "calculate", False, os.getcwd()))
     go_event, exit_event = (Event(), Event())
     go_event.set()
     run(queue, args_queue, go_event, exit_event)

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -34,6 +34,13 @@ def mock_rat_main(*args, **kwargs):
     return 1, 2, 3
 
 
+def close_processes(runner):
+    # Non serialised queue does not have a close attribute so have to mock it out
+    runner.queue.close = MagicMock()
+    runner.arg_queue.close = MagicMock()
+    runner.stop_processes()
+
+
 @patch("rascal2.core.runner.MatlabHelper", autospec=True)
 @patch("rascal2.core.runner.Process")
 @patch("rascal2.core.runner.RATRunner.get_new_process")
@@ -42,16 +49,16 @@ def test_start(mock_process_go_exit, mock_process, mock_matlab):
     mock_matlab.return_value = MagicMock()
     mock_go = MagicMock()
     mock_process_go_exit.return_value = MagicMock(), (mock_go, MagicMock())
-    runner = RATRunner(start_runners_early=False)
+    runner = RATRunner(start_runners_early=False, num_cores=1)
     runner.process = MagicMock()
-    runner.num_cores = MagicMock(return_value=1)
+    runner.get_runner_matlab_engine = MagicMock()
     runner.set_runner_args(make_rat_input(), "", True)
     runner.start()
 
     mock_go.set.assert_called_once()
     assert runner.timer.isActive()
 
-    runner.stop_processes()
+    close_processes(runner)
 
 
 @patch("rascal2.core.runner.MatlabHelper", autospec=True)
@@ -59,7 +66,7 @@ def test_start(mock_process_go_exit, mock_process, mock_matlab):
 def test_interrupt(mock_process, mock_matlab):
     """Test that `interrupt` kills the process and stops the timer."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner(start_runners_early=False)
+    runner = RATRunner(start_runners_early=False, num_cores=1)
     runner.process = MagicMock()
     runner.set_runner_args([], "", True)
     runner.interrupt()
@@ -67,7 +74,7 @@ def test_interrupt(mock_process, mock_matlab):
     runner.process.kill.assert_called_once()
     assert not runner.timer.isActive()
 
-    runner.stop_processes()
+    close_processes(runner)
 
 
 @pytest.mark.parametrize(
@@ -86,8 +93,9 @@ def test_interrupt(mock_process, mock_matlab):
 def test_check_queue(mock_process, mock_matlab, queue_items):
     """Test that queue data is appropriately assigned."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner(start_runners_early=False)
+    runner = RATRunner(start_runners_early=False, num_cores=1)
     runner.process = MagicMock()
+    runner.get_runner_matlab_engine = MagicMock()
     runner.set_runner_args([], "", True)
     runner.queue = Queue()
 
@@ -110,7 +118,7 @@ def test_check_queue(mock_process, mock_matlab, queue_items):
         assert isinstance(runner.error, ValueError)
         assert str(runner.error) == "Runner error!"
 
-    runner.stop_processes()
+    close_processes(runner)
 
 
 @patch("rascal2.core.runner.MatlabHelper", autospec=True)
@@ -118,15 +126,16 @@ def test_check_queue(mock_process, mock_matlab, queue_items):
 def test_empty_queue(mock_process, mock_matlab):
     """Test that nothing happens if the queue is empty."""
     mock_matlab.return_value = MagicMock()
-    runner = RATRunner(start_runners_early=False)
+    runner = RATRunner(start_runners_early=False, num_cores=1)
     runner.process = MagicMock()
     runner.set_runner_args(make_rat_input(), "", True)
+
     runner.check_queue()
 
     assert len(runner.events) == 0
     assert runner.results is None
 
-    runner.stop_processes()
+    close_processes(runner)
 
 
 @pytest.mark.parametrize("display", [True, False])
@@ -139,7 +148,7 @@ def test_run(display):
     arg_queue.put((make_rat_input(), "", display))
     go_event, exit_event = (Event(), Event())
     go_event.set()
-    run(queue, arg_queue, None, None, go_event, exit_event)
+    run(queue, arg_queue, go_event, exit_event)
 
     expected_display = [
         LogData(20, "Starting RAT"),
@@ -178,7 +187,7 @@ def test_run_error():
         args_queue.put((make_rat_input(), "", True))
         go_event, exit_event = (Event(), Event())
         go_event.set()
-        run(queue, args_queue, None, None, go_event, exit_event)
+        run(queue, args_queue, go_event, exit_event)
 
     queue.put(None)
     queue_contents = list(iter(queue.get, None))
@@ -207,7 +216,7 @@ def test_run_examples(example):
     args_queue.put((rat_inputs, "calculate", False))
     go_event, exit_event = (Event(), Event())
     go_event.set()
-    run(queue, args_queue, None, None, go_event, exit_event)
+    run(queue, args_queue, go_event, exit_event)
 
     output = queue.get()
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -35,12 +35,17 @@ def test_integration(qt_application, make_main_window):
     _ = qt_application
     window = make_main_window()
     window.show()
+    print("test_integration 1")
 
     window.presenter.create_project("project", ".")
+    print("test_integration 2")
     names = [win.windowTitle() for win in window.mdi.subWindowList()]
+    print("test_integration 3")
     # QMDIArea is first in last out hence the reversed list
     assert names == ["Fitting Controls", "Terminal", "Project", "Plots"]
+    print("test_integration 4")
 
     # Work through the different sections of the UI
 
     window.close()
+    print("test_integration 5")

--- a/tests/ui/test_presenter.py
+++ b/tests/ui/test_presenter.py
@@ -53,9 +53,9 @@ def presenter():
     with (
         patch("rascal2.ui.presenter.LOGGER", autospec=True) as mock_log,
         patch("rascal2.ui.model.os.chdir", autospec=True),
+        patch("rascal2.ui.presenter.RATRunner", autospec=True, return_value=MagicMock()),
     ):
         pr = MainWindowPresenter(MockWindowView())
-        pr.runner = MagicMock()
         pr.model.controls = Controls()
         pr.model.project = MagicMock()
         pr.model.project.name = "test_name"

--- a/tests/ui/test_view.py
+++ b/tests/ui/test_view.py
@@ -33,6 +33,7 @@ def test_view():
     with (
         patch("rascal2.widgets.plot.FigureCanvasQTAgg", return_value=MockFigureCanvas()),
         patch("rascal2.widgets.plot.NavigationToolbar2QT", return_value=MockNavigationToolbar()),
+        patch("rascal2.ui.presenter.RATRunner", autospec=True, return_value=MagicMock()),
     ):
         yield MainWindowView()
 
@@ -116,7 +117,8 @@ def test_set_enabled(test_view):
 
 @patch("PyQt6.QtWidgets.QFileDialog.getExistingDirectory")
 @patch("rascal2.ui.view.get_global_settings")
-def test_get_project_folder(mock_get_global, mock_get_dir: MagicMock):
+@patch("rascal2.ui.presenter.RATRunner", autospec=True, return_value=MagicMock())
+def test_get_project_folder(mock_runner, mock_get_global, mock_get_dir: MagicMock):
     """Test that getting a specified folder works as expected."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         ini_file = Path(tmp_dir) / "settings.ini"
@@ -206,7 +208,8 @@ def test_help_menu_actions_present(test_view, submenu_name, action_names_and_lay
         assert action.text() == name
 
 
-def test_toggle_slider():
+@patch("rascal2.ui.presenter.RATRunner", autospec=True, return_value=MagicMock())
+def test_toggle_slider(mock_runner):
     mw = MainWindowView()
     with patch.object(mw, "project_widget") as project_mock:
         show_text = mw.toggle_slider_action.property("show_text")

--- a/tests/widgets/project/test_slider_view.py
+++ b/tests/widgets/project/test_slider_view.py
@@ -52,7 +52,8 @@ def draft_project():
     return draft
 
 
-def test_no_sliders_creation():
+@patch("rascal2.ui.presenter.RATRunner", autospec=True, return_value=MagicMock())
+def test_no_sliders_creation(mock_runner):
     """Slider view should show warning when there is no fitted parameter."""
     mw = MainWindowView()
     draft = create_draft_project(ratapi.Project())
@@ -64,7 +65,8 @@ def test_no_sliders_creation():
     assert label.text().startswith("There are no fitted parameters")
 
 
-def test_sliders_creation(draft_project):
+@patch("rascal2.ui.presenter.RATRunner", autospec=True, return_value=MagicMock())
+def test_sliders_creation(mock_runner, draft_project):
     """Sliders should be created for fitted parameter only."""
     mw = MainWindowView()
     slider_view = SliderViewWidget(draft_project, mw)
@@ -81,7 +83,8 @@ def test_sliders_creation(draft_project):
     assert draft_project["parameters"][0].name not in slider_view._sliders
 
 
-def test_accept_and_cancel_slider_buttons():
+@patch("rascal2.ui.presenter.RATRunner", autospec=True, return_value=MagicMock())
+def test_accept_and_cancel_slider_buttons(mock_runner):
     mw = MainWindowView()
     draft = create_draft_project(ratapi.Project())
     mw.toggle_sliders = MagicMock()


### PR DESCRIPTION
This PR aims to reduce the amount of time that RasCAL-2 takes from pressing "run" to displaying the results in the UI. A lot of this time is taken by the overhead of creating the `Process` object in the RATRunner and then running `Process().start()` as there is computing power taken to move data around.

This PR moves this overhead time to the startup of RasCAL-2, where it is less noticable to the users. On startup, the `MainWindowPresenter` initialises the RATRunner and starts up the Processes held in a list accessable to the RATRunner object. All of the processes are started but do not actually do anything useful until a `go_event` is set. Upon pressing "run", a `go_event` signal is sent to the currently selected process and it begins running the RAT calculation.

This change in the RATRunner workflow causes the users experience to be a lot more fluid and the UI is more responsive. 
Comparing the times taken to run RasCAL-2 to this PR: (old -> new)

"calculate": 3.52s -> 0.65s
"dream": 11.2s -> 6.7s
"simplex": 5.5s -> 2.8s



